### PR TITLE
fix: resolve 14 TypeScript build errors in core package

### DIFF
--- a/packages/core/src/admission-stats.ts
+++ b/packages/core/src/admission-stats.ts
@@ -185,7 +185,8 @@ export function getAdmittedDecisionTimestamp(
 export function getObservedAdmissionCategory(
   entry: AdmissionAuditedMemoryLike,
 ): string {
-  return parseSmartMetadata(entry.metadata, entry).memory_category || entry.category || "patterns";
+  // entry.category is a free-form string; cast to satisfy EntryLike's LegacyStoreCategory
+  return parseSmartMetadata(entry.metadata, entry as Parameters<typeof parseSmartMetadata>[1]).memory_category || entry.category || "patterns";
 }
 
 export function buildAdmissionCategoryBreakdown(

--- a/packages/core/src/category-migrator.ts
+++ b/packages/core/src/category-migrator.ts
@@ -25,7 +25,7 @@ export function migrateCategoryForEntry(entry: EntryLike): MigrationResult {
   }
 
   if (parsed.memory_category && typeof parsed.memory_category === "string") {
-    return { memory_category: parsed.memory_category, changed: false };
+    return { memory_category: parsed.memory_category as MemoryCategory, changed: false };
   }
 
   const derived = reverseMapLegacyCategory(entry.category as any, entry.text);

--- a/packages/core/src/memory-upgrader.ts
+++ b/packages/core/src/memory-upgrader.ts
@@ -60,6 +60,7 @@ interface EnrichedMetadata {
   last_accessed_at: number;
   upgraded_from: string; // original 5-category
   upgraded_at: number;   // timestamp of upgrade
+  [key: string]: unknown;
 }
 
 // ============================================================================

--- a/packages/core/src/reflection-event-store.ts
+++ b/packages/core/src/reflection-event-store.ts
@@ -19,6 +19,7 @@ export interface ReflectionEventMetadata {
   usedFallback: boolean;
   errorSignals: string[];
   sourceReflectionPath?: string;
+  [key: string]: unknown;
 }
 
 export interface ReflectionEventPayload {

--- a/packages/core/src/reflection-item-store.ts
+++ b/packages/core/src/reflection-item-store.ts
@@ -23,6 +23,7 @@ export interface ReflectionItemMetadata {
   baseWeight: number;
   quality: number;
   sourceReflectionPath?: string;
+  [key: string]: unknown;
 }
 
 export interface ReflectionItemPayload {

--- a/packages/core/src/retriever.ts
+++ b/packages/core/src/retriever.ts
@@ -190,11 +190,11 @@ export const DEFAULT_RETRIEVAL_CONFIG: RetrievalConfig = {
  * If a result's category has an entry in `thresholds`, that value is used;
  * otherwise `hardMinScore` is the fallback.
  */
-export function applyCategoryThreshold(
-  results: Array<{ entry: { category: string }; score: number }>,
+export function applyCategoryThreshold<T extends { entry: { category: string }; score: number }>(
+  results: T[],
   thresholds: Record<string, number>,
   hardMinScore: number,
-): Array<{ entry: { category: string }; score: number }> {
+): T[] {
   return results.filter((r) => {
     const threshold = thresholds[r.entry.category] ?? hardMinScore;
     return r.score >= threshold;
@@ -260,12 +260,13 @@ function applyRelationBoostWithTrace<T extends { score: number; scoringTrace?: i
   candidates: Array<T & { entry: { id: string; metadata?: string } }>,
   debug?: boolean,
 ): typeof candidates {
+  type C = typeof candidates;
   if (!debug) {
-    return applyRelationBoost(candidates);
+    return applyRelationBoost(candidates) as C;
   }
   // Snapshot pre-boost scores
   const preBoost = new Map(candidates.map((c) => [c.entry.id, c.score]));
-  const boosted = applyRelationBoost(candidates);
+  const boosted = applyRelationBoost(candidates) as C;
   for (const c of boosted) {
     if (c.scoringTrace) {
       const delta = c.score - (preBoost.get(c.entry.id) ?? c.score);

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -171,6 +171,7 @@ async function retrieveWithRetry(
     limit: number;
     scopeFilter?: string[];
     category?: string;
+    source?: "manual" | "auto-recall" | "cli";
   },
 ): Promise<RetrievalResult[]> {
   let results = await retriever.retrieve(params);
@@ -1594,7 +1595,7 @@ export function registerMemoryPromoteTool(
             memoryId ?? query ?? "",
             scopeFilter,
           );
-          if (!resolved.ok) {
+          if (resolved.ok === false) {
             return {
               content: [{ type: "text", text: resolved.message }],
               details: resolved.details ?? { error: "resolve_failed" },
@@ -1697,7 +1698,7 @@ export function registerMemoryArchiveTool(
             memoryId ?? query ?? "",
             scopeFilter,
           );
-          if (!resolved.ok) {
+          if (resolved.ok === false) {
             return {
               content: [{ type: "text", text: resolved.message }],
               details: resolved.details ?? { error: "resolve_failed" },


### PR DESCRIPTION
## Summary

- After merging PRs #11, #13, #14, `tsc` fails with 14 type errors across 7 files
- All fixes are minimal type assertions / interface extensions, zero logic changes
- `pnpm --filter @ultramemory/core build` now passes clean

## Changes

| File | Fix |
|------|-----|
| `retriever.ts` | Generic type preservation in `applyCategoryThreshold`, type assertions in `applyRelationBoostWithTrace` |
| `tools.ts` | Add missing `source` field to `retrieveWithRetry`, fix union narrowing for `resolveMemoryId` |
| `admission-stats.ts` | Cast for `parseSmartMetadata` compat |
| `category-migrator.ts` | Cast parsed category to `MemoryCategory` |
| `memory-upgrader.ts`, `reflection-event-store.ts`, `reflection-item-store.ts` | Index signatures for `Record<string, unknown>` assignability |

## Test plan

- [x] `pnpm --filter @ultramemory/core build` — clean (0 errors)
- [x] `node --test test/access-tracker.test.mjs` — 59 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)