### PR TITLE
feat: auto-consolidation with dual-threshold trigger

### DIFF
--- a/packages/core/src/auto-consolidation.ts
+++ b/packages/core/src/auto-consolidation.ts
@@ -1,0 +1,165 @@
+/**
+ * Auto Consolidation — dual-threshold trigger for the consolidation engine.
+ *
+ * Instead of requiring manual consolidation calls, this module tracks write
+ * count and elapsed time since the last consolidation run. When BOTH thresholds
+ * are exceeded, it fires the existing ConsolidationEngine automatically.
+ *
+ * Usage: call `maybeConsolidate()` after each memory write (e.g. in the
+ * ingestion pipeline or MCP store tool). The call is cheap when thresholds
+ * are not met — just two comparisons.
+ */
+
+import {
+  ConsolidationEngine,
+  type ConsolidationConfig,
+  type ConsolidationResult,
+  DEFAULT_CONSOLIDATION_CONFIG,
+} from "./consolidation-engine.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface AutoConsolidationConfig {
+  /** Minimum writes since last consolidation before triggering (default 50) */
+  minWritesSinceLastRun: number;
+  /** Minimum milliseconds since last consolidation (default 3_600_000 = 1 hour) */
+  minMsSinceLastRun: number;
+  /** Consolidation engine config (cluster/merge thresholds) */
+  consolidation: ConsolidationConfig;
+}
+
+export const DEFAULT_AUTO_CONSOLIDATION_CONFIG: AutoConsolidationConfig = {
+  minWritesSinceLastRun: 50,
+  minMsSinceLastRun: 3_600_000, // 1 hour
+  consolidation: DEFAULT_CONSOLIDATION_CONFIG,
+};
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+export type AutoConsolidationSkipReason =
+  | "insufficient_writes"
+  | "too_soon"
+  | "already_running";
+
+export interface AutoConsolidationResult {
+  triggered: boolean;
+  reason?: AutoConsolidationSkipReason;
+  consolidation?: ConsolidationResult;
+}
+
+// ---------------------------------------------------------------------------
+// Duck-typed store interface (same shape as ConsolidationEngine expects)
+// ---------------------------------------------------------------------------
+
+interface StoreLike {
+  list(
+    scopeFilter?: string[],
+    category?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<unknown[]>;
+
+  getById(id: string, scopeFilter?: string[]): Promise<unknown | null>;
+
+  vectorSearch(
+    vector: number[],
+    limit?: number,
+    minScore?: number,
+    scopeFilter?: string[],
+    options?: { excludeInactive?: boolean; column?: string },
+  ): Promise<unknown[]>;
+
+  patchMetadata(
+    id: string,
+    patch: Record<string, unknown>,
+    scopeFilter?: string[],
+  ): Promise<unknown | null>;
+}
+
+// ---------------------------------------------------------------------------
+// AutoConsolidation
+// ---------------------------------------------------------------------------
+
+export class AutoConsolidation {
+  private writesSinceLastRun = 0;
+  private lastRunTimestamp = 0;
+  private running = false;
+  private readonly config: AutoConsolidationConfig;
+  private readonly store: StoreLike;
+
+  constructor(store: StoreLike, config?: Partial<AutoConsolidationConfig>) {
+    this.store = store;
+    this.config = {
+      ...DEFAULT_AUTO_CONSOLIDATION_CONFIG,
+      ...config,
+      consolidation: {
+        ...DEFAULT_CONSOLIDATION_CONFIG,
+        ...config?.consolidation,
+      },
+    };
+  }
+
+  /**
+   * Record a write and check whether consolidation should fire.
+   * Returns immediately (no-op) when thresholds are not met or a run is
+   * already in progress.
+   */
+  async maybeConsolidate(scope: string): Promise<AutoConsolidationResult> {
+    this.writesSinceLastRun++;
+
+    // Gate 1: enough writes?
+    if (this.writesSinceLastRun < this.config.minWritesSinceLastRun) {
+      return { triggered: false, reason: "insufficient_writes" };
+    }
+
+    // Gate 2: enough time elapsed?
+    const elapsed = Date.now() - this.lastRunTimestamp;
+    if (elapsed < this.config.minMsSinceLastRun) {
+      return { triggered: false, reason: "too_soon" };
+    }
+
+    // Gate 3: prevent concurrent runs
+    if (this.running) {
+      return { triggered: false, reason: "already_running" };
+    }
+
+    // Both thresholds met — run consolidation
+    this.running = true;
+    try {
+      const engine = new ConsolidationEngine(
+        this.store as any,
+        this.config.consolidation,
+      );
+      const result = await engine.run(scope);
+
+      // Reset counters on success
+      this.writesSinceLastRun = 0;
+      this.lastRunTimestamp = Date.now();
+
+      return { triggered: true, consolidation: result };
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /** Current write count since last consolidation. */
+  get writeCount(): number {
+    return this.writesSinceLastRun;
+  }
+
+  /** Timestamp (ms) of the last consolidation run (0 if never). */
+  get lastRunTime(): number {
+    return this.lastRunTimestamp;
+  }
+
+  /** Reset internal state (for testing). */
+  reset(): void {
+    this.writesSinceLastRun = 0;
+    this.lastRunTimestamp = 0;
+    this.running = false;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -139,6 +139,9 @@ export { detectFactKeyConflict, detectHeuristicContradiction } from "./conflict-
 // Consolidation engine
 export { ConsolidationEngine, DEFAULT_CONSOLIDATION_CONFIG, type ConsolidationConfig, type ConsolidationResult, type ConflictEvent } from "./consolidation-engine.js";
 
+// Auto-consolidation (dual-threshold trigger)
+export { AutoConsolidation, DEFAULT_AUTO_CONSOLIDATION_CONFIG, type AutoConsolidationConfig, type AutoConsolidationResult, type AutoConsolidationSkipReason } from "./auto-consolidation.js";
+
 // Contextual recall rendering
 export { renderMemories, type RenderMode, type RenderResult, type RenderedMemory, type RenderableMemory } from "./context-renderer.js";
 

--- a/test/auto-consolidation.test.mjs
+++ b/test/auto-consolidation.test.mjs
@@ -1,0 +1,237 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+const {
+  AutoConsolidation,
+  DEFAULT_AUTO_CONSOLIDATION_CONFIG,
+} = jiti("../packages/core/src/auto-consolidation.ts");
+
+// ============================================================================
+// Mock store — minimal duck-typed interface for ConsolidationEngine
+// ============================================================================
+
+function createMockStore() {
+  return {
+    _entries: /** @type {Map<string, object>} */ (new Map()),
+    _listCalls: 0,
+
+    async list(_scopeFilter, _category, _limit, _offset) {
+      this._listCalls++;
+      return [...this._entries.values()];
+    },
+    async getById(id) {
+      return this._entries.get(id) ?? null;
+    },
+    async vectorSearch(_vector, _limit, _minScore, _scopeFilter, _options) {
+      return [];
+    },
+    async patchMetadata(id, patch) {
+      const entry = this._entries.get(id);
+      if (!entry) return null;
+      const meta = JSON.parse(/** @type {any} */ (entry).metadata || "{}");
+      Object.assign(meta, patch);
+      /** @type {any} */ (entry).metadata = JSON.stringify(meta);
+      return entry;
+    },
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("AutoConsolidation", () => {
+  /** @type {ReturnType<typeof createMockStore>} */
+  let store;
+  /** @type {InstanceType<typeof AutoConsolidation>} */
+  let auto;
+
+  beforeEach(() => {
+    store = createMockStore();
+  });
+
+  describe("default config", () => {
+    it("exports sensible defaults", () => {
+      assert.strictEqual(DEFAULT_AUTO_CONSOLIDATION_CONFIG.minWritesSinceLastRun, 50);
+      assert.strictEqual(DEFAULT_AUTO_CONSOLIDATION_CONFIG.minMsSinceLastRun, 3_600_000);
+      assert.ok(DEFAULT_AUTO_CONSOLIDATION_CONFIG.consolidation);
+    });
+  });
+
+  describe("insufficient_writes gate", () => {
+    it("does not trigger when write count is below threshold", async () => {
+      auto = new AutoConsolidation(store, { minWritesSinceLastRun: 3, minMsSinceLastRun: 0 });
+
+      const r1 = await auto.maybeConsolidate("test-scope");
+      assert.strictEqual(r1.triggered, false);
+      assert.strictEqual(r1.reason, "insufficient_writes");
+      assert.strictEqual(auto.writeCount, 1);
+
+      const r2 = await auto.maybeConsolidate("test-scope");
+      assert.strictEqual(r2.triggered, false);
+      assert.strictEqual(r2.reason, "insufficient_writes");
+      assert.strictEqual(auto.writeCount, 2);
+    });
+  });
+
+  describe("too_soon gate", () => {
+    it("does not trigger when not enough time has passed", async () => {
+      // Set write threshold to 1 so it passes immediately, but time to 1 hour
+      auto = new AutoConsolidation(store, {
+        minWritesSinceLastRun: 1,
+        minMsSinceLastRun: 3_600_000,
+      });
+
+      // First call: lastRunTimestamp is 0, so elapsed = Date.now() - 0 > 1h → triggers
+      const r1 = await auto.maybeConsolidate("test-scope");
+      assert.strictEqual(r1.triggered, true);
+
+      // Second call: just ran, so elapsed < 1h → too_soon
+      const r2 = await auto.maybeConsolidate("test-scope");
+      assert.strictEqual(r2.triggered, false);
+      assert.strictEqual(r2.reason, "too_soon");
+    });
+  });
+
+  describe("dual threshold — triggers consolidation", () => {
+    it("triggers when both write count and time thresholds are exceeded", async () => {
+      auto = new AutoConsolidation(store, {
+        minWritesSinceLastRun: 2,
+        minMsSinceLastRun: 0, // no time gate for this test
+      });
+
+      // First write — not enough writes yet
+      const r1 = await auto.maybeConsolidate("test-scope");
+      assert.strictEqual(r1.triggered, false);
+
+      // Second write — threshold met, should trigger
+      const r2 = await auto.maybeConsolidate("test-scope");
+      assert.strictEqual(r2.triggered, true);
+      assert.ok(r2.consolidation);
+      assert.strictEqual(r2.consolidation.scope, "test-scope");
+      assert.strictEqual(typeof r2.consolidation.mergedCount, "number");
+
+      // After trigger, counters reset — next call should not trigger
+      const r3 = await auto.maybeConsolidate("test-scope");
+      assert.strictEqual(r3.triggered, false);
+      assert.strictEqual(r3.reason, "insufficient_writes");
+    });
+  });
+
+  describe("consolidation result shape", () => {
+    it("returns full ConsolidationResult when triggered", async () => {
+      // Seed some entries so consolidation has data to process
+      store._entries.set("a", {
+        id: "a",
+        text: "hello world",
+        vector: [1, 0, 0],
+        category: "fact",
+        scope: "s",
+        importance: 0.5,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+      store._entries.set("b", {
+        id: "b",
+        text: "hello earth",
+        vector: [1, 0, 0],
+        category: "fact",
+        scope: "s",
+        importance: 0.3,
+        timestamp: Date.now(),
+        metadata: "{}",
+      });
+
+      auto = new AutoConsolidation(store, {
+        minWritesSinceLastRun: 1,
+        minMsSinceLastRun: 0,
+      });
+
+      const r = await auto.maybeConsolidate("s");
+      assert.strictEqual(r.triggered, true);
+
+      const c = r.consolidation;
+      assert.ok(c);
+      assert.strictEqual(typeof c.originalCount, "number");
+      assert.strictEqual(typeof c.clustersFound, "number");
+      assert.strictEqual(typeof c.mergedCount, "number");
+      assert.strictEqual(typeof c.relationsAdded, "number");
+      assert.ok(Array.isArray(c.conflictsDetected));
+      assert.strictEqual(c.scope, "s");
+    });
+  });
+
+  describe("reset()", () => {
+    it("resets internal state", async () => {
+      auto = new AutoConsolidation(store, {
+        minWritesSinceLastRun: 5,
+        minMsSinceLastRun: 0,
+      });
+
+      // Accumulate some writes
+      await auto.maybeConsolidate("s");
+      await auto.maybeConsolidate("s");
+      assert.strictEqual(auto.writeCount, 2);
+
+      auto.reset();
+      assert.strictEqual(auto.writeCount, 0);
+      assert.strictEqual(auto.lastRunTime, 0);
+    });
+  });
+
+  describe("concurrent run guard", () => {
+    it("prevents re-entrant consolidation", async () => {
+      // Create a slow store that delays list() to simulate a long-running consolidation
+      let resolveList;
+      const slowStore = {
+        ...createMockStore(),
+        async list() {
+          return new Promise((resolve) => {
+            resolveList = () => resolve([]);
+          });
+        },
+      };
+
+      auto = new AutoConsolidation(slowStore, {
+        minWritesSinceLastRun: 1,
+        minMsSinceLastRun: 0,
+      });
+
+      // Start first consolidation (will hang on list)
+      const p1 = auto.maybeConsolidate("s");
+
+      // Try a second one immediately — should get already_running
+      // Need enough writes to pass the write gate
+      const r2 = await auto.maybeConsolidate("s");
+      assert.strictEqual(r2.triggered, false);
+      assert.strictEqual(r2.reason, "already_running");
+
+      // Unblock the first consolidation
+      resolveList();
+      const r1 = await p1;
+      assert.strictEqual(r1.triggered, true);
+    });
+  });
+
+  describe("custom consolidation config passthrough", () => {
+    it("passes consolidation config to the engine", async () => {
+      auto = new AutoConsolidation(store, {
+        minWritesSinceLastRun: 1,
+        minMsSinceLastRun: 0,
+        consolidation: {
+          clusterThreshold: 0.90,
+          mergeThreshold: 0.95,
+          abstractionMinClusterSize: 10,
+          maxEntriesPerRun: 100,
+        },
+      });
+
+      // Just verify it doesn't throw with custom config
+      const r = await auto.maybeConsolidate("s");
+      assert.strictEqual(r.triggered, true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `AutoConsolidation` class that automatically triggers the existing `ConsolidationEngine` when **both** a write-count threshold (default 50) and a time-elapsed threshold (default 1 hour) are exceeded
- Designed to be called after each memory write via `maybeConsolidate(scope)` — returns immediately (two comparisons) when thresholds are not met
- Includes a concurrent-run guard to prevent overlapping consolidation runs

## Design
- **Dual gate**: consolidation fires only when `writesSinceLastRun >= minWritesSinceLastRun` AND `elapsed >= minMsSinceLastRun`. This prevents thrashing on low-traffic scopes while ensuring high-traffic scopes stay consolidated.
- **Class-based state** (not module globals) for testability and multi-instance support
- **No LLM calls** in the trigger logic — purely deterministic gating around the existing engine
- Ported from RecallNest's `auto-consolidation.ts`, adapted for UltraMemory's duck-typed `StoreLike` pattern and `ConsolidationEngine` API

## Files changed
| File | Change |
|------|--------|
| `packages/core/src/auto-consolidation.ts` | New module: `AutoConsolidation` class |
| `packages/core/src/index.ts` | Export the new module |
| `test/auto-consolidation.test.mjs` | 8 tests covering all gates, reset, concurrency, config passthrough |

## Test plan
- [x] `node --test test/auto-consolidation.test.mjs` — 8/8 pass
- [ ] Verify no regressions in existing test suite
- [ ] Integration: wire `maybeConsolidate()` into ingestion pipeline or MCP store tool (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)