### PR TITLE
feat: retroactive boost (STC) for low-importance memory promotion

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -133,6 +133,9 @@ export * from "./utils/deterministic-id.js";
 // Ingestion pipeline
 export { IngestionPipeline, type IngestionInput, type IngestionResult, type IngestionAction } from "./ingestion-pipeline.js";
 
+// Retroactive boost
+export { retroactiveBoost, DEFAULT_RETROACTIVE_BOOST_CONFIG, type RetroactiveBoostConfig, type BoostResult } from "./retroactive-boost.js";
+
 // Conflict detection
 export { detectFactKeyConflict, detectHeuristicContradiction } from "./conflict-detector.js";
 

--- a/packages/core/src/ingestion-pipeline.ts
+++ b/packages/core/src/ingestion-pipeline.ts
@@ -98,6 +98,7 @@ export class IngestionPipeline {
   private dupThreshold: number;
   private conflictEnabled: boolean;
   private kgExtractor?: KGExtractor;
+  private boostConfig: RetroactiveBoostConfig | false;
 
   constructor(config: IngestionPipelineConfig) {
     this.store = config.store;
@@ -105,6 +106,7 @@ export class IngestionPipeline {
     this.dupThreshold = config.dupThreshold ?? 0.98;
     this.conflictEnabled = config.conflictEnabled ?? true;
     this.kgExtractor = config.kgExtractor;
+    this.boostConfig = config.retroactiveBoost ?? DEFAULT_RETROACTIVE_BOOST_CONFIG;
   }
 
   async ingest(input: IngestionInput): Promise<IngestionResult> {
@@ -341,7 +343,21 @@ export class IngestionPipeline {
     }
 
     // -----------------------------------------------------------------------
-    // 10. KG triple extraction (fire-and-forget, non-blocking)
+    // 10. Retroactive boost — lift related low-importance older entries
+    // -----------------------------------------------------------------------
+    if (this.boostConfig !== false && newId) {
+      retroactiveBoost(this.store, {
+        id: newId,
+        text: input.text,
+        vector: mainVector,
+        importance: input.importance,
+        scope: input.scope,
+        timestamp: Date.now(),
+      }, this.boostConfig).catch(() => {});
+    }
+
+    // -----------------------------------------------------------------------
+    // 11. KG triple extraction (fire-and-forget, non-blocking)
     // -----------------------------------------------------------------------
     if (this.kgExtractor && newId) {
       this.kgExtractor.extractAndStore(input.text, newId, input.scope).catch(() => {});

--- a/packages/core/src/ingestion-pipeline.ts
+++ b/packages/core/src/ingestion-pipeline.ts
@@ -18,6 +18,7 @@ import {
 import { detectFactKeyConflict } from "./conflict-detector.js";
 import type { MemoryCategory } from "./memory-categories.js";
 import type { KGExtractor } from "./kg-extractor.js";
+import { retroactiveBoost, DEFAULT_RETROACTIVE_BOOST_CONFIG, type RetroactiveBoostConfig } from "./retroactive-boost.js";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/packages/core/src/retroactive-boost.ts
+++ b/packages/core/src/retroactive-boost.ts
@@ -1,0 +1,176 @@
+/**
+ * Retroactive Boost (STC — Synaptic Tagging & Capture)
+ *
+ * When a new high-importance memory is stored, older related but
+ * low-importance memories become more valuable. This module finds
+ * those older entries via vector search and bumps their importance
+ * so they surface in future retrievals.
+ *
+ * Rules:
+ * - Only triggers on high-importance writes (>= triggerImportanceMin)
+ * - Only boosts entries whose current importance is below boostCandidateMaxImportance
+ * - Boost is additive with a ceiling — never exceeds maxBoostedImportance
+ * - Writes metadata breadcrumb (stc_boosts) for auditability
+ * - No LLM calls — pure vector search + arithmetic
+ */
+
+import type { MemoryStore, MemoryEntry } from "./store.js";
+import { parseSmartMetadata, stringifySmartMetadata } from "./smart-metadata.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface RetroactiveBoostConfig {
+  /** Minimum importance of the NEW memory to trigger a boost sweep (default 0.8) */
+  triggerImportanceMin: number;
+  /** Only boost entries whose current importance is below this (default 0.6) */
+  boostCandidateMaxImportance: number;
+  /** Additive importance bump (default 0.15) */
+  boostAmount: number;
+  /** Ceiling: boosted importance never exceeds this (default 0.75) */
+  maxBoostedImportance: number;
+  /** Minimum vector similarity to consider "related" (default 0.72) */
+  similarityThreshold: number;
+  /** Maximum entries to boost per trigger (default 5) */
+  maxBoostPerTrigger: number;
+  /** Minimum age in days for a candidate (avoid boosting very recent entries) (default 1) */
+  minAgeDays: number;
+}
+
+export const DEFAULT_RETROACTIVE_BOOST_CONFIG: RetroactiveBoostConfig = {
+  triggerImportanceMin: 0.8,
+  boostCandidateMaxImportance: 0.6,
+  boostAmount: 0.15,
+  maxBoostedImportance: 0.75,
+  similarityThreshold: 0.72,
+  maxBoostPerTrigger: 5,
+  minAgeDays: 1,
+};
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+export interface BoostResult {
+  triggered: boolean;
+  reason?: string;
+  boostedCount: number;
+  boostedIds: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Core
+// ---------------------------------------------------------------------------
+
+/**
+ * After a high-importance memory is stored, search for related older
+ * low-importance entries and boost them.
+ *
+ * Call this right after store.store() for the new entry.
+ */
+export async function retroactiveBoost(
+  store: MemoryStore,
+  newEntry: Pick<MemoryEntry, "id" | "text" | "vector" | "importance" | "scope" | "timestamp">,
+  config: RetroactiveBoostConfig = DEFAULT_RETROACTIVE_BOOST_CONFIG,
+): Promise<BoostResult> {
+  // Gate: only trigger for high-importance new memories
+  if (newEntry.importance < config.triggerImportanceMin) {
+    return { triggered: false, reason: "below_importance_threshold", boostedCount: 0, boostedIds: [] };
+  }
+
+  if (!newEntry.vector?.length) {
+    return { triggered: false, reason: "no_vector", boostedCount: 0, boostedIds: [] };
+  }
+
+  // Find related entries in the same scope
+  let candidates;
+  try {
+    candidates = await store.vectorSearch(
+      newEntry.vector,
+      config.maxBoostPerTrigger * 3, // fetch more, filter down
+      config.similarityThreshold,
+      [newEntry.scope],
+    );
+  } catch {
+    return { triggered: true, reason: "vector_search_failed", boostedCount: 0, boostedIds: [] };
+  }
+
+  const now = Date.now();
+  const minAgeMs = config.minAgeDays * 86_400_000;
+  const boostedIds: string[] = [];
+
+  for (const candidate of candidates) {
+    if (boostedIds.length >= config.maxBoostPerTrigger) break;
+
+    const entry = candidate.entry;
+
+    // Skip self
+    if (entry.id === newEntry.id) continue;
+
+    // Skip entries that are already high importance
+    if (entry.importance >= config.boostCandidateMaxImportance) continue;
+
+    // Skip very recent entries (they'll get their own natural scoring)
+    const ageMs = now - entry.timestamp;
+    if (ageMs < minAgeMs) continue;
+
+    // Compute boost: additive, capped
+    const newImportance = Math.min(
+      entry.importance + config.boostAmount,
+      config.maxBoostedImportance,
+    );
+
+    // Skip if no actual change
+    if (newImportance <= entry.importance) continue;
+
+    // Update metadata with audit trail
+    let meta: Record<string, any> = {};
+    try { meta = JSON.parse(entry.metadata || "{}"); } catch { /* skip */ }
+
+    if (!Array.isArray(meta.stc_boosts)) meta.stc_boosts = [];
+    meta.stc_boosts.push({
+      triggeredBy: newEntry.id.slice(0, 8),
+      from: entry.importance,
+      to: newImportance,
+      similarity: candidate.score,
+      date: new Date().toISOString().slice(0, 10),
+    });
+
+    // Promote tier if appropriate
+    if (meta.tier === "peripheral" && newImportance >= 0.5) {
+      meta.tier = "working";
+    }
+
+    // Use delete + importEntry to work around LanceDB's add-then-delete
+    // update pattern which removes both old and new rows when the ID is
+    // unchanged (same deterministic ID for same scope+text).
+    // Convert Arrow Vector to plain array for importEntry validation.
+    const plainVector = Array.isArray(entry.vector)
+      ? entry.vector
+      : Array.from(entry.vector as Iterable<number>);
+    try {
+      await store.delete(entry.id, [newEntry.scope]);
+      await store.importEntry({
+        ...entry,
+        vector: plainVector,
+        importance: newImportance,
+        metadata: JSON.stringify(meta),
+      });
+    } catch (err) {
+      // Best-effort — don't fail the whole boost if one update fails
+      if (process.env.ULTRAMEMORY_DEBUG) {
+        console.warn("[retroactive-boost] update failed:", err);
+      }
+      continue;
+    }
+
+    boostedIds.push(entry.id);
+  }
+
+  return {
+    triggered: true,
+    boostedCount: boostedIds.length,
+    boostedIds,
+  };
+}

--- a/test/retroactive-boost.test.mjs
+++ b/test/retroactive-boost.test.mjs
@@ -1,0 +1,334 @@
+/**
+ * Retroactive Boost Tests
+ *
+ * Verifies that high-importance new memories boost related older
+ * low-importance entries, and respects all config thresholds.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const { MemoryStore } = jiti("../packages/core/src/store.ts");
+const { retroactiveBoost, DEFAULT_RETROACTIVE_BOOST_CONFIG } = jiti(
+  "../packages/core/src/retroactive-boost.ts",
+);
+
+const DIM = 4;
+
+describe("retroactiveBoost", () => {
+  let workDir;
+  let store;
+
+  beforeEach(async () => {
+    workDir = mkdtempSync(path.join(tmpdir(), "retro-boost-test-"));
+    store = new MemoryStore({
+      dbPath: path.join(workDir, "db"),
+      vectorDim: DIM,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  // Helper: store an entry with a specific timestamp in the past
+  async function storeOldEntry(overrides = {}) {
+    const base = {
+      text: "old memory",
+      vector: [1, 0, 0, 0],
+      category: "fact",
+      scope: "test",
+      importance: 0.3,
+      metadata: JSON.stringify({ tier: "peripheral" }),
+      ...overrides,
+    };
+    const entry = await store.store(base);
+    // Backdate the entry to make it old enough for boosting
+    const twoDaysAgo = Date.now() - 2 * 86_400_000;
+    await store.update(entry.id, { importance: base.importance }, ["test"]);
+    // Use direct update to backdate timestamp (patchMetadata can't set timestamp)
+    // We'll configure minAgeDays=0 in tests instead for simplicity
+    return entry;
+  }
+
+  it("should skip when new entry importance is below threshold", async () => {
+    const result = await retroactiveBoost(store, {
+      id: "new-id",
+      text: "low importance entry",
+      vector: [1, 0, 0, 0],
+      importance: 0.5, // below default threshold of 0.8
+      scope: "test",
+      timestamp: Date.now(),
+    });
+
+    assert.equal(result.triggered, false);
+    assert.equal(result.reason, "below_importance_threshold");
+    assert.equal(result.boostedCount, 0);
+  });
+
+  it("should skip when new entry has no vector", async () => {
+    const result = await retroactiveBoost(store, {
+      id: "new-id",
+      text: "no vector",
+      vector: [],
+      importance: 0.9,
+      scope: "test",
+      timestamp: Date.now(),
+    });
+
+    assert.equal(result.triggered, false);
+    assert.equal(result.reason, "no_vector");
+  });
+
+  it("should boost low-importance related entries", async () => {
+    // Store an old low-importance entry with a similar vector
+    const old = await store.store({
+      text: "old related memory",
+      vector: [0.9, 0.1, 0, 0],
+      category: "fact",
+      scope: "test",
+      importance: 0.3,
+      metadata: JSON.stringify({ tier: "peripheral" }),
+    });
+
+    // Trigger boost with a high-importance entry and similar vector
+    const config = {
+      ...DEFAULT_RETROACTIVE_BOOST_CONFIG,
+      triggerImportanceMin: 0.8,
+      similarityThreshold: 0.1, // low threshold for test vectors
+      minAgeDays: 0, // disable age check for tests
+    };
+
+    const result = await retroactiveBoost(
+      store,
+      {
+        id: "new-high-importance",
+        text: "important new memory",
+        vector: [1, 0, 0, 0],
+        importance: 0.9,
+        scope: "test",
+        timestamp: Date.now(),
+      },
+      config,
+    );
+
+    assert.equal(result.triggered, true);
+    assert.equal(result.boostedCount, 1);
+    assert.ok(result.boostedIds.includes(old.id));
+
+    // Verify the old entry was updated
+    const updated = await store.getById(old.id);
+    assert.ok(updated.importance > 0.3, `Expected importance > 0.3, got ${updated.importance}`);
+    assert.ok(
+      updated.importance <= config.maxBoostedImportance,
+      `Expected importance <= ${config.maxBoostedImportance}, got ${updated.importance}`,
+    );
+
+    // Verify audit trail in metadata
+    const meta = JSON.parse(updated.metadata);
+    assert.ok(Array.isArray(meta.stc_boosts), "Should have stc_boosts array");
+    assert.equal(meta.stc_boosts.length, 1);
+    assert.equal(meta.stc_boosts[0].from, 0.3);
+    assert.equal(meta.stc_boosts[0].to, 0.3 + config.boostAmount);
+  });
+
+  it("should not boost entries already above candidate threshold", async () => {
+    await store.store({
+      text: "already important memory",
+      vector: [0.9, 0.1, 0, 0],
+      category: "fact",
+      scope: "test",
+      importance: 0.7, // above default boostCandidateMaxImportance (0.6)
+    });
+
+    const config = {
+      ...DEFAULT_RETROACTIVE_BOOST_CONFIG,
+      similarityThreshold: 0.1,
+      minAgeDays: 0,
+    };
+
+    const result = await retroactiveBoost(
+      store,
+      {
+        id: "new-id",
+        text: "trigger memory",
+        vector: [1, 0, 0, 0],
+        importance: 0.9,
+        scope: "test",
+        timestamp: Date.now(),
+      },
+      config,
+    );
+
+    assert.equal(result.triggered, true);
+    assert.equal(result.boostedCount, 0);
+  });
+
+  it("should not boost entries in different scopes", async () => {
+    await store.store({
+      text: "other scope memory",
+      vector: [0.9, 0.1, 0, 0],
+      category: "fact",
+      scope: "other-scope",
+      importance: 0.2,
+    });
+
+    const config = {
+      ...DEFAULT_RETROACTIVE_BOOST_CONFIG,
+      similarityThreshold: 0.1,
+      minAgeDays: 0,
+    };
+
+    const result = await retroactiveBoost(
+      store,
+      {
+        id: "new-id",
+        text: "trigger memory",
+        vector: [1, 0, 0, 0],
+        importance: 0.9,
+        scope: "test", // different scope
+        timestamp: Date.now(),
+      },
+      config,
+    );
+
+    assert.equal(result.triggered, true);
+    assert.equal(result.boostedCount, 0);
+  });
+
+  it("should cap boosted importance at maxBoostedImportance", async () => {
+    const old = await store.store({
+      text: "entry near ceiling",
+      vector: [0.9, 0.1, 0, 0],
+      category: "fact",
+      scope: "test",
+      importance: 0.55, // below 0.6 candidate max
+    });
+
+    const config = {
+      ...DEFAULT_RETROACTIVE_BOOST_CONFIG,
+      boostAmount: 0.5, // would push to 1.05 without cap
+      maxBoostedImportance: 0.75,
+      similarityThreshold: 0.1,
+      minAgeDays: 0,
+    };
+
+    const result = await retroactiveBoost(
+      store,
+      {
+        id: "new-id",
+        text: "trigger memory",
+        vector: [1, 0, 0, 0],
+        importance: 0.9,
+        scope: "test",
+        timestamp: Date.now(),
+      },
+      config,
+    );
+
+    assert.equal(result.boostedCount, 1);
+
+    const updated = await store.getById(old.id);
+    assert.equal(
+      updated.importance,
+      config.maxBoostedImportance,
+      `Importance should be capped at ${config.maxBoostedImportance}`,
+    );
+  });
+
+  it("should respect maxBoostPerTrigger limit", async () => {
+    // Store more candidates than the limit
+    for (let i = 0; i < 5; i++) {
+      await store.store({
+        text: `low importance memory ${i}`,
+        vector: [0.9 + i * 0.01, 0.1, 0, 0],
+        category: "fact",
+        scope: "test",
+        importance: 0.2,
+      });
+    }
+
+    const config = {
+      ...DEFAULT_RETROACTIVE_BOOST_CONFIG,
+      maxBoostPerTrigger: 2,
+      similarityThreshold: 0.1,
+      minAgeDays: 0,
+    };
+
+    const result = await retroactiveBoost(
+      store,
+      {
+        id: "new-id",
+        text: "trigger memory",
+        vector: [1, 0, 0, 0],
+        importance: 0.9,
+        scope: "test",
+        timestamp: Date.now(),
+      },
+      config,
+    );
+
+    assert.equal(result.triggered, true);
+    assert.ok(
+      result.boostedCount <= config.maxBoostPerTrigger,
+      `Expected at most ${config.maxBoostPerTrigger} boosts, got ${result.boostedCount}`,
+    );
+  });
+
+  it("should promote tier from peripheral to working when boosted above 0.5", async () => {
+    const old = await store.store({
+      text: "peripheral tier memory",
+      vector: [0.9, 0.1, 0, 0],
+      category: "fact",
+      scope: "test",
+      importance: 0.3,
+      metadata: JSON.stringify({ tier: "peripheral" }),
+    });
+
+    const config = {
+      ...DEFAULT_RETROACTIVE_BOOST_CONFIG,
+      boostAmount: 0.25, // 0.3 + 0.25 = 0.55, above 0.5
+      similarityThreshold: 0.1,
+      minAgeDays: 0,
+    };
+
+    const result = await retroactiveBoost(
+      store,
+      {
+        id: "new-id",
+        text: "trigger memory",
+        vector: [1, 0, 0, 0],
+        importance: 0.9,
+        scope: "test",
+        timestamp: Date.now(),
+      },
+      config,
+    );
+
+    assert.equal(result.boostedCount, 1);
+
+    const updated = await store.getById(old.id);
+    const meta = JSON.parse(updated.metadata);
+    assert.equal(meta.tier, "working", "Tier should be promoted to working");
+  });
+
+  it("should use default config when none provided", async () => {
+    // Just verify it doesn't throw with default config
+    const result = await retroactiveBoost(store, {
+      id: "new-id",
+      text: "test memory",
+      vector: [1, 0, 0, 0],
+      importance: 0.9,
+      scope: "test",
+      timestamp: Date.now(),
+    });
+
+    assert.equal(result.triggered, true);
+    assert.equal(typeof result.boostedCount, "number");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds retroactive boost module (`retroactive-boost.ts`): when a high-importance memory is stored, semantically similar older low-importance entries are boosted so they surface in future retrievals
- Wired into `IngestionPipeline` as step 10 (fire-and-forget, non-blocking) with configurable thresholds and opt-out (`retroactiveBoost: false`)
- Ported from RecallNest's STC (Synaptic Tagging & Capture) implementation, adapted for UltraMemory's store interface

### Key design decisions
- Uses `delete` + `importEntry` instead of `store.update()` to work around LanceDB's add-then-delete pattern which removes both old and new rows when the ID is unchanged
- Converts Arrow Vector to plain `number[]` for `importEntry` compatibility
- Writes `stc_boosts` audit trail in metadata for traceability
- Promotes tier from `peripheral` to `working` when boosted importance >= 0.5

### Config defaults
| Parameter | Default | Description |
|-----------|---------|-------------|
| triggerImportanceMin | 0.8 | Min importance of new memory to trigger sweep |
| boostCandidateMaxImportance | 0.6 | Only boost entries below this |
| boostAmount | 0.15 | Additive bump |
| maxBoostedImportance | 0.75 | Ceiling for boosted importance |
| similarityThreshold | 0.72 | Min vector similarity |
| maxBoostPerTrigger | 5 | Max entries boosted per trigger |
| minAgeDays | 1 | Skip very recent entries |

## Test plan

- [x] Skip when new entry importance below threshold
- [x] Skip when new entry has no vector
- [x] Boost low-importance related entries and verify audit trail
- [x] Do not boost entries already above candidate threshold
- [x] Do not boost entries in different scopes
- [x] Cap boosted importance at maxBoostedImportance
- [x] Respect maxBoostPerTrigger limit
- [x] Promote tier from peripheral to working
- [x] Use default config when none provided
- [x] All 9 tests passing (`node --test test/retroactive-boost.test.mjs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)