### PR TITLE
feat: add confidence tracker for memory scoring

### DIFF
--- a/packages/core/src/confidence-tracker.ts
+++ b/packages/core/src/confidence-tracker.ts
@@ -1,0 +1,286 @@
+/**
+ * Confidence Tracker — observation-based confidence scoring for memories.
+ *
+ * When a user corrects information ("actually it's X not Y"), the corrected
+ * version gets higher confidence while the old version gets demoted. This
+ * prevents stale/wrong information from having equal weight to verified facts.
+ *
+ * Confidence semantics:
+ * - 1.0  = explicitly confirmed by user
+ * - 0.8  = confirmed (standard confirmation bump)
+ * - 0.5  = default (unverified)
+ * - 0.2  = corrected / superseded
+ * - 0.0  = explicitly contradicted
+ *
+ * Retrieval integration: confidence multiplies into the score pipeline
+ * as `score *= (0.5 + 0.5 * confidence)` — same pattern used by
+ * importance weighting in the decay engine.
+ *
+ * Time decay: confidence decays toward 0.5 (neutral) over time without
+ * reconfirmation, using a gentle half-life of 90 days.
+ *
+ * Ported from RecallNest's confidence-tracker.ts, adapted for UltraMemory's
+ * SmartMemoryMetadata structure.
+ */
+
+import type { SmartMemoryMetadata } from "./smart-metadata.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Unverified default confidence */
+export const CONFIDENCE_DEFAULT = 0.5;
+
+/** User explicitly confirmed */
+export const CONFIDENCE_CONFIRMED = 0.8;
+
+/** Strongly confirmed (repeated confirmations) */
+export const CONFIDENCE_STRONG = 1.0;
+
+/** Corrected / superseded by newer info */
+export const CONFIDENCE_CORRECTED = 0.2;
+
+/** Explicitly contradicted — should almost never surface */
+export const CONFIDENCE_CONTRADICTED = 0.0;
+
+/** Days for confidence to decay halfway back toward CONFIDENCE_DEFAULT */
+export const CONFIDENCE_DECAY_HALF_LIFE_DAYS = 90;
+
+const MS_PER_DAY = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// Confidence history — stored in metadata.confidence_history
+// ---------------------------------------------------------------------------
+
+export interface ConfidenceHistoryEntry {
+  action: "confirmed" | "corrected" | "contradicted" | "decayed";
+  from: number;
+  to: number;
+  date: string;
+  /** For corrections: the ID of the memory that replaced this one */
+  correctedBy?: string;
+}
+
+export interface ConfidenceUpdate {
+  entryId: string;
+  oldConfidence: number;
+  newConfidence: number;
+}
+
+// ---------------------------------------------------------------------------
+// Read helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract confidence from a SmartMemoryMetadata object.
+ * Returns CONFIDENCE_DEFAULT (0.5) if not set or invalid.
+ */
+export function getConfidence(metadata: Pick<SmartMemoryMetadata, "confidence">): number {
+  const c = metadata.confidence;
+  return typeof c === "number" && Number.isFinite(c) ? clamp01(c) : CONFIDENCE_DEFAULT;
+}
+
+/**
+ * Extract confidence_history from metadata's extra fields.
+ */
+export function getConfidenceHistory(
+  metadata: Record<string, unknown>,
+): ConfidenceHistoryEntry[] {
+  const raw = metadata.confidence_history;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (e): e is ConfidenceHistoryEntry =>
+      !!e &&
+      typeof e === "object" &&
+      typeof (e as Record<string, unknown>).action === "string" &&
+      typeof (e as Record<string, unknown>).from === "number" &&
+      typeof (e as Record<string, unknown>).to === "number",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Core operations — return metadata patches (no store dependency)
+// ---------------------------------------------------------------------------
+
+/** Max history entries to keep per memory */
+const MAX_CONFIDENCE_HISTORY = 20;
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+function pushHistory(
+  existing: ConfidenceHistoryEntry[],
+  entry: ConfidenceHistoryEntry,
+): ConfidenceHistoryEntry[] {
+  const next = [...existing, entry];
+  if (next.length > MAX_CONFIDENCE_HISTORY) {
+    return next.slice(next.length - MAX_CONFIDENCE_HISTORY);
+  }
+  return next;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Build a metadata patch for confirming a memory.
+ * Bumps confidence to CONFIDENCE_CONFIRMED (0.8), or to CONFIDENCE_STRONG
+ * (1.0) if already at or above CONFIDENCE_CONFIRMED.
+ */
+export function buildConfirmPatch(
+  metadata: Record<string, unknown>,
+): { confidence: number; confidence_history: ConfidenceHistoryEntry[] } {
+  const oldConfidence = typeof metadata.confidence === "number"
+    ? clamp01(metadata.confidence)
+    : CONFIDENCE_DEFAULT;
+  const newConfidence = oldConfidence >= CONFIDENCE_CONFIRMED
+    ? CONFIDENCE_STRONG
+    : CONFIDENCE_CONFIRMED;
+  const history = getConfidenceHistory(metadata);
+  return {
+    confidence: newConfidence,
+    confidence_history: pushHistory(history, {
+      action: "confirmed",
+      from: oldConfidence,
+      to: newConfidence,
+      date: today(),
+    }),
+  };
+}
+
+/**
+ * Build a metadata patch for correcting a memory (user provided updated info).
+ * Drops confidence to CONFIDENCE_CORRECTED (0.2).
+ */
+export function buildCorrectPatch(
+  metadata: Record<string, unknown>,
+  correctedById?: string,
+): { confidence: number; confidence_history: ConfidenceHistoryEntry[] } {
+  const oldConfidence = typeof metadata.confidence === "number"
+    ? clamp01(metadata.confidence)
+    : CONFIDENCE_DEFAULT;
+  const history = getConfidenceHistory(metadata);
+  const entry: ConfidenceHistoryEntry = {
+    action: "corrected",
+    from: oldConfidence,
+    to: CONFIDENCE_CORRECTED,
+    date: today(),
+  };
+  if (correctedById) {
+    entry.correctedBy = correctedById.slice(0, 8);
+  }
+  return {
+    confidence: CONFIDENCE_CORRECTED,
+    confidence_history: pushHistory(history, entry),
+  };
+}
+
+/**
+ * Build a metadata patch for contradicting a memory (explicitly wrong).
+ * Drops confidence to CONFIDENCE_CONTRADICTED (0.0).
+ */
+export function buildContradictPatch(
+  metadata: Record<string, unknown>,
+): { confidence: number; confidence_history: ConfidenceHistoryEntry[] } {
+  const oldConfidence = typeof metadata.confidence === "number"
+    ? clamp01(metadata.confidence)
+    : CONFIDENCE_DEFAULT;
+  const history = getConfidenceHistory(metadata);
+  return {
+    confidence: CONFIDENCE_CONTRADICTED,
+    confidence_history: pushHistory(history, {
+      action: "contradicted",
+      from: oldConfidence,
+      to: CONFIDENCE_CONTRADICTED,
+      date: today(),
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Time decay
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute confidence after time decay. Confidence drifts toward
+ * CONFIDENCE_DEFAULT (0.5) over time without reconfirmation.
+ *
+ * Formula: decayed = default + (current - default) * 2^(-elapsed / halfLife)
+ *
+ * At halfLife days, confidence moves halfway back to 0.5.
+ * A memory confirmed at 1.0 would be 0.75 after 90 days, 0.625 after 180 days.
+ * A memory corrected to 0.2 would be 0.35 after 90 days, 0.425 after 180 days.
+ *
+ * @param currentConfidence - The stored confidence value
+ * @param elapsedMs - Milliseconds since last confidence update
+ * @param halfLifeDays - Days for half-decay (default: CONFIDENCE_DECAY_HALF_LIFE_DAYS)
+ * @returns The decayed confidence value, clamped to [0, 1]
+ */
+export function decayConfidence(
+  currentConfidence: number,
+  elapsedMs: number,
+  halfLifeDays: number = CONFIDENCE_DECAY_HALF_LIFE_DAYS,
+): number {
+  if (elapsedMs <= 0 || halfLifeDays <= 0) return currentConfidence;
+  const elapsedDays = elapsedMs / MS_PER_DAY;
+  const decayFactor = Math.pow(2, -elapsedDays / halfLifeDays);
+  const decayed = CONFIDENCE_DEFAULT + (currentConfidence - CONFIDENCE_DEFAULT) * decayFactor;
+  return clamp01(decayed);
+}
+
+/**
+ * Build a metadata patch applying time decay to confidence.
+ * Only produces a patch if the decayed value differs meaningfully
+ * from the current value (> 0.01 delta).
+ *
+ * @param metadata - Current metadata record
+ * @param lastUpdateMs - Timestamp (ms) of the last confidence update
+ * @param now - Current timestamp (ms), defaults to Date.now()
+ * @returns A patch object, or null if no meaningful decay occurred
+ */
+export function buildDecayPatch(
+  metadata: Record<string, unknown>,
+  lastUpdateMs: number,
+  now: number = Date.now(),
+): { confidence: number; confidence_history: ConfidenceHistoryEntry[] } | null {
+  const current = typeof metadata.confidence === "number"
+    ? clamp01(metadata.confidence)
+    : CONFIDENCE_DEFAULT;
+  const elapsed = now - lastUpdateMs;
+  const decayed = decayConfidence(current, elapsed);
+  if (Math.abs(decayed - current) < 0.01) return null;
+
+  const history = getConfidenceHistory(metadata);
+  return {
+    confidence: decayed,
+    confidence_history: pushHistory(history, {
+      action: "decayed",
+      from: current,
+      to: decayed,
+      date: new Date(now).toISOString().slice(0, 10),
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Retrieval weighting
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply confidence weighting to a retrieval score.
+ *
+ * Formula: score *= (0.5 + 0.5 * confidence)
+ *
+ * At confidence=1.0 -> x1.0  (no penalty)
+ * At confidence=0.8 -> x0.9  (mild boost vs default)
+ * At confidence=0.5 -> x0.75 (baseline)
+ * At confidence=0.2 -> x0.6  (significant penalty)
+ * At confidence=0.0 -> x0.5  (heavy penalty)
+ */
+export function applyConfidenceWeight(score: number, confidence: number): number {
+  const c = clamp01(confidence);
+  return score * (0.5 + 0.5 * c);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,9 @@ export * from "./extraction-prompts.js";
 // Smart metadata
 export * from "./smart-metadata.js";
 
+// Confidence tracking
+export * from "./confidence-tracker.js";
+
 // Decay & tier management
 export * from "./decay-engine.js";
 export * from "./tier-manager.js";

--- a/test/confidence-tracker.test.mjs
+++ b/test/confidence-tracker.test.mjs
@@ -1,0 +1,307 @@
+/**
+ * Confidence Tracker Tests
+ *
+ * Verifies confidence scoring, time decay, and retrieval weighting.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const {
+  CONFIDENCE_DEFAULT,
+  CONFIDENCE_CONFIRMED,
+  CONFIDENCE_STRONG,
+  CONFIDENCE_CORRECTED,
+  CONFIDENCE_CONTRADICTED,
+  CONFIDENCE_DECAY_HALF_LIFE_DAYS,
+  getConfidence,
+  getConfidenceHistory,
+  buildConfirmPatch,
+  buildCorrectPatch,
+  buildContradictPatch,
+  decayConfidence,
+  buildDecayPatch,
+  applyConfidenceWeight,
+} = jiti("../packages/core/src/confidence-tracker.ts");
+
+const MS_PER_DAY = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe("confidence constants", () => {
+  it("should have correct default values", () => {
+    assert.equal(CONFIDENCE_DEFAULT, 0.5);
+    assert.equal(CONFIDENCE_CONFIRMED, 0.8);
+    assert.equal(CONFIDENCE_STRONG, 1.0);
+    assert.equal(CONFIDENCE_CORRECTED, 0.2);
+    assert.equal(CONFIDENCE_CONTRADICTED, 0.0);
+    assert.equal(CONFIDENCE_DECAY_HALF_LIFE_DAYS, 90);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getConfidence
+// ---------------------------------------------------------------------------
+
+describe("getConfidence", () => {
+  it("should return confidence from metadata", () => {
+    assert.equal(getConfidence({ confidence: 0.8 }), 0.8);
+  });
+
+  it("should return default when confidence is missing", () => {
+    assert.equal(getConfidence({}), CONFIDENCE_DEFAULT);
+  });
+
+  it("should clamp out-of-range values", () => {
+    assert.equal(getConfidence({ confidence: 1.5 }), 1.0);
+    assert.equal(getConfidence({ confidence: -0.3 }), 0.0);
+  });
+
+  it("should return default for non-numeric confidence", () => {
+    assert.equal(getConfidence({ confidence: "high" }), CONFIDENCE_DEFAULT);
+    assert.equal(getConfidence({ confidence: NaN }), CONFIDENCE_DEFAULT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getConfidenceHistory
+// ---------------------------------------------------------------------------
+
+describe("getConfidenceHistory", () => {
+  it("should return empty array when no history", () => {
+    assert.deepEqual(getConfidenceHistory({}), []);
+    assert.deepEqual(getConfidenceHistory({ confidence_history: "not-array" }), []);
+  });
+
+  it("should filter invalid entries", () => {
+    const history = getConfidenceHistory({
+      confidence_history: [
+        { action: "confirmed", from: 0.5, to: 0.8, date: "2026-01-01" },
+        { bad: "entry" },
+        null,
+        { action: "corrected", from: 0.8, to: 0.2, date: "2026-01-02" },
+      ],
+    });
+    assert.equal(history.length, 2);
+    assert.equal(history[0].action, "confirmed");
+    assert.equal(history[1].action, "corrected");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildConfirmPatch
+// ---------------------------------------------------------------------------
+
+describe("buildConfirmPatch", () => {
+  it("should raise unverified confidence to CONFIRMED", () => {
+    const patch = buildConfirmPatch({ confidence: CONFIDENCE_DEFAULT });
+    assert.equal(patch.confidence, CONFIDENCE_CONFIRMED);
+    assert.equal(patch.confidence_history.length, 1);
+    assert.equal(patch.confidence_history[0].action, "confirmed");
+    assert.equal(patch.confidence_history[0].from, CONFIDENCE_DEFAULT);
+    assert.equal(patch.confidence_history[0].to, CONFIDENCE_CONFIRMED);
+  });
+
+  it("should raise already-confirmed to STRONG", () => {
+    const patch = buildConfirmPatch({ confidence: CONFIDENCE_CONFIRMED });
+    assert.equal(patch.confidence, CONFIDENCE_STRONG);
+    assert.equal(patch.confidence_history[0].from, CONFIDENCE_CONFIRMED);
+    assert.equal(patch.confidence_history[0].to, CONFIDENCE_STRONG);
+  });
+
+  it("should use default confidence when field is missing", () => {
+    const patch = buildConfirmPatch({});
+    assert.equal(patch.confidence, CONFIDENCE_CONFIRMED);
+    assert.equal(patch.confidence_history[0].from, CONFIDENCE_DEFAULT);
+  });
+
+  it("should preserve existing history", () => {
+    const existing = {
+      confidence: 0.6,
+      confidence_history: [
+        { action: "decayed", from: 0.8, to: 0.6, date: "2026-01-01" },
+      ],
+    };
+    const patch = buildConfirmPatch(existing);
+    assert.equal(patch.confidence_history.length, 2);
+    assert.equal(patch.confidence_history[0].action, "decayed");
+    assert.equal(patch.confidence_history[1].action, "confirmed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCorrectPatch
+// ---------------------------------------------------------------------------
+
+describe("buildCorrectPatch", () => {
+  it("should drop confidence to CORRECTED", () => {
+    const patch = buildCorrectPatch({ confidence: CONFIDENCE_CONFIRMED });
+    assert.equal(patch.confidence, CONFIDENCE_CORRECTED);
+    assert.equal(patch.confidence_history[0].action, "corrected");
+    assert.equal(patch.confidence_history[0].from, CONFIDENCE_CONFIRMED);
+  });
+
+  it("should include correctedBy when provided", () => {
+    const patch = buildCorrectPatch(
+      { confidence: 0.8 },
+      "abc12345-long-id",
+    );
+    assert.equal(patch.confidence_history[0].correctedBy, "abc12345");
+  });
+
+  it("should not include correctedBy when omitted", () => {
+    const patch = buildCorrectPatch({ confidence: 0.8 });
+    assert.equal(patch.confidence_history[0].correctedBy, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildContradictPatch
+// ---------------------------------------------------------------------------
+
+describe("buildContradictPatch", () => {
+  it("should drop confidence to CONTRADICTED", () => {
+    const patch = buildContradictPatch({ confidence: CONFIDENCE_DEFAULT });
+    assert.equal(patch.confidence, CONFIDENCE_CONTRADICTED);
+    assert.equal(patch.confidence_history[0].action, "contradicted");
+    assert.equal(patch.confidence_history[0].from, CONFIDENCE_DEFAULT);
+    assert.equal(patch.confidence_history[0].to, CONFIDENCE_CONTRADICTED);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decayConfidence
+// ---------------------------------------------------------------------------
+
+describe("decayConfidence", () => {
+  it("should not change confidence when no time elapsed", () => {
+    assert.equal(decayConfidence(1.0, 0), 1.0);
+    assert.equal(decayConfidence(0.2, 0), 0.2);
+  });
+
+  it("should decay confirmed confidence toward default over time", () => {
+    const halfLife = CONFIDENCE_DECAY_HALF_LIFE_DAYS;
+    const elapsed = halfLife * MS_PER_DAY;
+    const decayed = decayConfidence(CONFIDENCE_STRONG, elapsed);
+    // After one half-life: 0.5 + (1.0 - 0.5) * 0.5 = 0.75
+    assert.ok(Math.abs(decayed - 0.75) < 0.01, `expected ~0.75, got ${decayed}`);
+  });
+
+  it("should decay corrected confidence back toward default", () => {
+    const halfLife = CONFIDENCE_DECAY_HALF_LIFE_DAYS;
+    const elapsed = halfLife * MS_PER_DAY;
+    const decayed = decayConfidence(CONFIDENCE_CORRECTED, elapsed);
+    // After one half-life: 0.5 + (0.2 - 0.5) * 0.5 = 0.35
+    assert.ok(Math.abs(decayed - 0.35) < 0.01, `expected ~0.35, got ${decayed}`);
+  });
+
+  it("should not move if already at default", () => {
+    const decayed = decayConfidence(CONFIDENCE_DEFAULT, 365 * MS_PER_DAY);
+    assert.equal(decayed, CONFIDENCE_DEFAULT);
+  });
+
+  it("should stay clamped in [0, 1]", () => {
+    // Even extreme values should never escape bounds
+    assert.ok(decayConfidence(0.0, 1000 * MS_PER_DAY) >= 0);
+    assert.ok(decayConfidence(1.0, 1000 * MS_PER_DAY) <= 1);
+  });
+
+  it("should handle negative elapsed gracefully", () => {
+    assert.equal(decayConfidence(0.8, -100), 0.8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDecayPatch
+// ---------------------------------------------------------------------------
+
+describe("buildDecayPatch", () => {
+  it("should return null when decay is insignificant", () => {
+    const now = Date.now();
+    const result = buildDecayPatch(
+      { confidence: 0.8 },
+      now - MS_PER_DAY, // just 1 day ago — tiny decay
+      now,
+    );
+    assert.equal(result, null);
+  });
+
+  it("should return a patch when decay is significant", () => {
+    const now = Date.now();
+    const result = buildDecayPatch(
+      { confidence: 1.0 },
+      now - 90 * MS_PER_DAY, // one full half-life
+      now,
+    );
+    assert.notEqual(result, null);
+    assert.ok(result.confidence < 1.0);
+    assert.ok(Math.abs(result.confidence - 0.75) < 0.01);
+    assert.equal(result.confidence_history.length, 1);
+    assert.equal(result.confidence_history[0].action, "decayed");
+  });
+
+  it("should return null when already at default", () => {
+    const now = Date.now();
+    const result = buildDecayPatch(
+      { confidence: CONFIDENCE_DEFAULT },
+      now - 365 * MS_PER_DAY,
+      now,
+    );
+    assert.equal(result, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyConfidenceWeight
+// ---------------------------------------------------------------------------
+
+describe("applyConfidenceWeight", () => {
+  it("should apply correct multiplier at confidence=1.0", () => {
+    assert.equal(applyConfidenceWeight(1.0, 1.0), 1.0);
+  });
+
+  it("should apply correct multiplier at confidence=0.5", () => {
+    assert.equal(applyConfidenceWeight(1.0, 0.5), 0.75);
+  });
+
+  it("should apply correct multiplier at confidence=0.0", () => {
+    assert.equal(applyConfidenceWeight(1.0, 0.0), 0.5);
+  });
+
+  it("should scale the input score proportionally", () => {
+    assert.equal(applyConfidenceWeight(2.0, 1.0), 2.0);
+    assert.equal(applyConfidenceWeight(2.0, 0.0), 1.0);
+  });
+
+  it("should clamp out-of-range confidence", () => {
+    assert.equal(applyConfidenceWeight(1.0, 1.5), 1.0);
+    assert.equal(applyConfidenceWeight(1.0, -0.5), 0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// History cap
+// ---------------------------------------------------------------------------
+
+describe("history cap", () => {
+  it("should cap history at 20 entries", () => {
+    const metadata = {
+      confidence: 0.5,
+      confidence_history: Array.from({ length: 25 }, (_, i) => ({
+        action: "confirmed",
+        from: 0.5,
+        to: 0.8,
+        date: `2026-01-${String(i + 1).padStart(2, "0")}`,
+      })),
+    };
+    const patch = buildConfirmPatch(metadata);
+    // 25 existing + 1 new = 26, capped to most recent 20
+    assert.equal(patch.confidence_history.length, 20);
+    // The newest entry should be the confirmation we just added
+    assert.equal(patch.confidence_history[19].action, "confirmed");
+  });
+});


### PR DESCRIPTION
## Summary
- Ports confidence tracking from RecallNest, adapted for UltraMemory's SmartMemoryMetadata structure
- Memories start at 0.5 (unverified), rise to 0.8/1.0 on user confirmation, drop to 0.2 on correction and 0.0 on contradiction
- Confidence decays toward 0.5 over a 90-day half-life without reconfirmation, preventing stale scores from persisting indefinitely
- Retrieval weighting via `score *= (0.5 + 0.5 * confidence)` -- same pattern as importance weighting
- Pure logic module returning metadata patches -- no store or LLM dependency, callers apply patches via `patchMetadata`

## Test plan
- [x] 30 tests covering all functions: constants, getConfidence, getConfidenceHistory, buildConfirmPatch, buildCorrectPatch, buildContradictPatch, decayConfidence, buildDecayPatch, applyConfidenceWeight, and history cap
- [x] `node --test test/confidence-tracker.test.mjs` -- all 30 pass
- [x] Build verified -- no new TS errors introduced (pre-existing errors in other files unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)