### PR TITLE
feat: add homeostasis (synaptic scaling) for core tier thresholds

### DIFF
--- a/packages/core/src/homeostasis.ts
+++ b/packages/core/src/homeostasis.ts
@@ -1,0 +1,84 @@
+/**
+ * Homeostasis — Synaptic Scaling for Memory Tier Thresholds
+ *
+ * When the core memory tier grows too large, retrieval quality degrades because
+ * too many entries compete for limited context window space. Homeostasis
+ * counteracts this by proportionally raising the thresholds required for core
+ * promotion, ensuring only the most relevant entries surface.
+ *
+ * This is a pure function — no store access, no LLM, just arithmetic.
+ *
+ * Ported from RecallNest's decay-engine.ts (synaptic homeostasis).
+ */
+
+import type { TierConfig } from "./tier-manager.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface HomeostasisConfig {
+  /** Maximum core tier entries before scaling kicks in (default: 500) */
+  cap: number;
+  /** How aggressively thresholds scale with overshoot (default: 0.5) */
+  scalingFactor: number;
+  /** Upper bound on the threshold multiplier (default: 2.0) */
+  maxMultiplier: number;
+}
+
+export const DEFAULT_HOMEOSTASIS_CONFIG: HomeostasisConfig = {
+  cap: 500,
+  scalingFactor: 0.5,
+  maxMultiplier: 2.0,
+};
+
+export interface TierCounts {
+  core: number;
+  working: number;
+  peripheral: number;
+}
+
+// ============================================================================
+// Core function
+// ============================================================================
+
+/**
+ * Compute homeostasis-adjusted tier thresholds.
+ *
+ * When `tierCounts.core` exceeds `config.cap`, the core-promotion thresholds
+ * in `baseThresholds` are scaled up proportionally:
+ *
+ *   overshoot = max(0, (coreCount - cap) / cap)
+ *   multiplier = clamp(1 + overshoot * scalingFactor, 1, maxMultiplier)
+ *
+ * Only core-promotion fields are affected:
+ * - `coreAccessThreshold` is scaled and ceil'd to an integer
+ * - `coreCompositeThreshold` is scaled and clamped to [0, 1]
+ * - `coreImportanceThreshold` is scaled and clamped to [0, 1]
+ *
+ * Demotion and working-promotion thresholds are left unchanged — homeostasis
+ * only tightens the gate into core, it does not alter other transitions.
+ */
+export function homeostasisAdjustedThresholds(
+  tierCounts: TierCounts,
+  baseThresholds: TierConfig,
+  config: Partial<HomeostasisConfig> = {},
+): TierConfig {
+  const { cap, scalingFactor, maxMultiplier } = {
+    ...DEFAULT_HOMEOSTASIS_CONFIG,
+    ...config,
+  };
+
+  const coreCount = tierCounts.core;
+  if (coreCount <= cap) return { ...baseThresholds };
+
+  const overshoot = Math.max(0, (coreCount - cap) / cap);
+  const multiplier = Math.min(1 + overshoot * scalingFactor, maxMultiplier);
+
+  return {
+    ...baseThresholds,
+    coreAccessThreshold: Math.ceil(baseThresholds.coreAccessThreshold * multiplier),
+    coreCompositeThreshold: Math.min(baseThresholds.coreCompositeThreshold * multiplier, 1),
+    coreImportanceThreshold: Math.min(baseThresholds.coreImportanceThreshold * multiplier, 1),
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export * from "./smart-metadata.js";
 // Decay & tier management
 export * from "./decay-engine.js";
 export * from "./tier-manager.js";
+export * from "./homeostasis.js";
 
 // Memory categories
 export * from "./memory-categories.js";

--- a/src/homeostasis.ts
+++ b/src/homeostasis.ts
@@ -1,0 +1,84 @@
+/**
+ * Homeostasis — Synaptic Scaling for Memory Tier Thresholds
+ *
+ * When the core memory tier grows too large, retrieval quality degrades because
+ * too many entries compete for limited context window space. Homeostasis
+ * counteracts this by proportionally raising the thresholds required for core
+ * promotion, ensuring only the most relevant entries surface.
+ *
+ * This is a pure function — no store access, no LLM, just arithmetic.
+ *
+ * Ported from RecallNest's decay-engine.ts (synaptic homeostasis).
+ */
+
+import type { TierConfig } from "./tier-manager.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface HomeostasisConfig {
+  /** Maximum core tier entries before scaling kicks in (default: 500) */
+  cap: number;
+  /** How aggressively thresholds scale with overshoot (default: 0.5) */
+  scalingFactor: number;
+  /** Upper bound on the threshold multiplier (default: 2.0) */
+  maxMultiplier: number;
+}
+
+export const DEFAULT_HOMEOSTASIS_CONFIG: HomeostasisConfig = {
+  cap: 500,
+  scalingFactor: 0.5,
+  maxMultiplier: 2.0,
+};
+
+export interface TierCounts {
+  core: number;
+  working: number;
+  peripheral: number;
+}
+
+// ============================================================================
+// Core function
+// ============================================================================
+
+/**
+ * Compute homeostasis-adjusted tier thresholds.
+ *
+ * When `tierCounts.core` exceeds `config.cap`, the core-promotion thresholds
+ * in `baseThresholds` are scaled up proportionally:
+ *
+ *   overshoot = max(0, (coreCount - cap) / cap)
+ *   multiplier = clamp(1 + overshoot * scalingFactor, 1, maxMultiplier)
+ *
+ * Only core-promotion fields are affected:
+ * - `coreAccessThreshold` is scaled and ceil'd to an integer
+ * - `coreCompositeThreshold` is scaled and clamped to [0, 1]
+ * - `coreImportanceThreshold` is scaled and clamped to [0, 1]
+ *
+ * Demotion and working-promotion thresholds are left unchanged — homeostasis
+ * only tightens the gate into core, it does not alter other transitions.
+ */
+export function homeostasisAdjustedThresholds(
+  tierCounts: TierCounts,
+  baseThresholds: TierConfig,
+  config: Partial<HomeostasisConfig> = {},
+): TierConfig {
+  const { cap, scalingFactor, maxMultiplier } = {
+    ...DEFAULT_HOMEOSTASIS_CONFIG,
+    ...config,
+  };
+
+  const coreCount = tierCounts.core;
+  if (coreCount <= cap) return { ...baseThresholds };
+
+  const overshoot = Math.max(0, (coreCount - cap) / cap);
+  const multiplier = Math.min(1 + overshoot * scalingFactor, maxMultiplier);
+
+  return {
+    ...baseThresholds,
+    coreAccessThreshold: Math.ceil(baseThresholds.coreAccessThreshold * multiplier),
+    coreCompositeThreshold: Math.min(baseThresholds.coreCompositeThreshold * multiplier, 1),
+    coreImportanceThreshold: Math.min(baseThresholds.coreImportanceThreshold * multiplier, 1),
+  };
+}

--- a/test/homeostasis.test.mjs
+++ b/test/homeostasis.test.mjs
@@ -1,0 +1,146 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+const {
+  homeostasisAdjustedThresholds,
+  DEFAULT_HOMEOSTASIS_CONFIG,
+} = jiti("../src/homeostasis.ts");
+
+const { DEFAULT_TIER_CONFIG } = jiti("../src/tier-manager.ts");
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function counts(core, working = 100, peripheral = 200) {
+  return { core, working, peripheral };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("homeostasisAdjustedThresholds", () => {
+  it("returns base thresholds unchanged when core count is below cap", () => {
+    const result = homeostasisAdjustedThresholds(
+      counts(200),
+      DEFAULT_TIER_CONFIG,
+    );
+    assert.deepEqual(result, DEFAULT_TIER_CONFIG);
+  });
+
+  it("returns base thresholds unchanged when core count equals cap", () => {
+    const result = homeostasisAdjustedThresholds(
+      counts(500),
+      DEFAULT_TIER_CONFIG,
+    );
+    assert.deepEqual(result, DEFAULT_TIER_CONFIG);
+  });
+
+  it("scales up core thresholds when core count exceeds cap", () => {
+    const result = homeostasisAdjustedThresholds(
+      counts(1000),
+      DEFAULT_TIER_CONFIG,
+    );
+    // overshoot = (1000 - 500) / 500 = 1.0
+    // multiplier = 1 + 1.0 * 0.5 = 1.5
+    assert.equal(result.coreAccessThreshold, Math.ceil(DEFAULT_TIER_CONFIG.coreAccessThreshold * 1.5));
+    // coreCompositeThreshold = 0.7 * 1.5 = 1.05, clamped to 1.0
+    assert.equal(result.coreCompositeThreshold, Math.min(DEFAULT_TIER_CONFIG.coreCompositeThreshold * 1.5, 1));
+    // coreImportanceThreshold = 0.8 * 1.5 = 1.2, clamped to 1.0
+    assert.equal(result.coreImportanceThreshold, Math.min(DEFAULT_TIER_CONFIG.coreImportanceThreshold * 1.5, 1));
+  });
+
+  it("does not modify working or peripheral thresholds", () => {
+    const result = homeostasisAdjustedThresholds(
+      counts(1500),
+      DEFAULT_TIER_CONFIG,
+    );
+    assert.equal(result.workingAccessThreshold, DEFAULT_TIER_CONFIG.workingAccessThreshold);
+    assert.equal(result.workingCompositeThreshold, DEFAULT_TIER_CONFIG.workingCompositeThreshold);
+    assert.equal(result.peripheralCompositeThreshold, DEFAULT_TIER_CONFIG.peripheralCompositeThreshold);
+    assert.equal(result.peripheralAgeDays, DEFAULT_TIER_CONFIG.peripheralAgeDays);
+  });
+
+  it("clamps multiplier at maxMultiplier", () => {
+    // At 5x the cap (2500), overshoot = 4.0, multiplier = 1 + 4.0 * 0.5 = 3.0, clamped to 2.0
+    const result = homeostasisAdjustedThresholds(
+      counts(2500),
+      DEFAULT_TIER_CONFIG,
+    );
+    assert.equal(result.coreAccessThreshold, Math.ceil(DEFAULT_TIER_CONFIG.coreAccessThreshold * 2.0));
+  });
+
+  it("clamps importance threshold at 1.0", () => {
+    // coreImportanceThreshold = 0.8, with multiplier 2.0 -> 1.6, clamped to 1.0
+    const base = { ...DEFAULT_TIER_CONFIG, coreImportanceThreshold: 0.8 };
+    const result = homeostasisAdjustedThresholds(
+      counts(2500),
+      base,
+      { cap: 500, scalingFactor: 0.5, maxMultiplier: 2.0 },
+    );
+    assert.equal(result.coreImportanceThreshold, 1.0);
+  });
+
+  it("clamps composite threshold at 1.0", () => {
+    const base = { ...DEFAULT_TIER_CONFIG, coreCompositeThreshold: 0.9 };
+    const result = homeostasisAdjustedThresholds(
+      counts(2500),
+      base,
+      { cap: 500, scalingFactor: 0.5, maxMultiplier: 2.0 },
+    );
+    assert.equal(result.coreCompositeThreshold, 1.0);
+  });
+
+  it("accepts custom cap, scalingFactor, and maxMultiplier", () => {
+    const result = homeostasisAdjustedThresholds(
+      counts(200),
+      DEFAULT_TIER_CONFIG,
+      { cap: 100, scalingFactor: 1.0, maxMultiplier: 3.0 },
+    );
+    // overshoot = (200 - 100) / 100 = 1.0
+    // multiplier = 1 + 1.0 * 1.0 = 2.0
+    assert.equal(result.coreAccessThreshold, Math.ceil(DEFAULT_TIER_CONFIG.coreAccessThreshold * 2.0));
+  });
+
+  it("ceils coreAccessThreshold to an integer", () => {
+    const base = { ...DEFAULT_TIER_CONFIG, coreAccessThreshold: 7 };
+    const result = homeostasisAdjustedThresholds(
+      counts(750),
+      base,
+      { cap: 500, scalingFactor: 0.5, maxMultiplier: 2.0 },
+    );
+    // overshoot = (750 - 500) / 500 = 0.5
+    // multiplier = 1 + 0.5 * 0.5 = 1.25
+    // 7 * 1.25 = 8.75 -> ceil -> 9
+    assert.equal(result.coreAccessThreshold, 9);
+  });
+
+  it("returns a new object, does not mutate the input", () => {
+    const base = { ...DEFAULT_TIER_CONFIG };
+    const original = { ...base };
+    homeostasisAdjustedThresholds(counts(1000), base);
+    assert.deepEqual(base, original);
+  });
+
+  it("applies partial config overrides correctly", () => {
+    // Only override cap, scalingFactor and maxMultiplier use defaults
+    const result = homeostasisAdjustedThresholds(
+      counts(300),
+      DEFAULT_TIER_CONFIG,
+      { cap: 200 },
+    );
+    // overshoot = (300 - 200) / 200 = 0.5
+    // multiplier = 1 + 0.5 * 0.5 = 1.25 (default scalingFactor = 0.5)
+    assert.equal(result.coreAccessThreshold, Math.ceil(DEFAULT_TIER_CONFIG.coreAccessThreshold * 1.25));
+  });
+
+  it("DEFAULT_HOMEOSTASIS_CONFIG has expected values", () => {
+    assert.equal(DEFAULT_HOMEOSTASIS_CONFIG.cap, 500);
+    assert.equal(DEFAULT_HOMEOSTASIS_CONFIG.scalingFactor, 0.5);
+    assert.equal(DEFAULT_HOMEOSTASIS_CONFIG.maxMultiplier, 2.0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `homeostasisAdjustedThresholds()` pure function that scales up core-promotion thresholds when the core memory tier grows beyond a configurable cap
- Prevents "everything is important = nothing is important" problem by proportionally raising access, composite, and importance thresholds for core promotion
- Formula: `multiplier = clamp(1 + overshoot * scalingFactor, 1, maxMultiplier)` where `overshoot = max(0, (coreCount - cap) / cap)`

## Details
- **New file**: `packages/core/src/homeostasis.ts` (+ mirror in `src/`)
- **Exported from**: `packages/core/src/index.ts`
- **Tests**: `test/homeostasis.test.mjs` — 12 tests covering below-cap passthrough, scaling math, clamping, immutability, partial config overrides
- **Config**: `cap` (default 500), `scalingFactor` (default 0.5), `maxMultiplier` (default 2.0)
- Pure function — no store access, no LLM, just arithmetic
- Ported from RecallNest's synaptic homeostasis implementation

## Test plan
- [x] All 12 unit tests pass (`node --test test/homeostasis.test.mjs`)
- [x] No build errors introduced (pre-existing TS errors are unrelated)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)