### PR TITLE
feat: add multi-hop retrieval for cross-session entity discovery

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,6 +127,9 @@ export * from "./feedback-learner.js";
 // Entity resolution
 export * from "./entity-resolver.js";
 
+// Multi-hop retrieval (optional two-round search)
+export * from "./multi-hop-retriever.js";
+
 // Deterministic IDs
 export * from "./utils/deterministic-id.js";
 

--- a/packages/core/src/multi-hop-retriever.ts
+++ b/packages/core/src/multi-hop-retriever.ts
@@ -1,0 +1,256 @@
+/**
+ * Multi-Hop Retrieval
+ *
+ * Ported from RecallNest LME-5. After a first-round search, extracts salient
+ * entities from the results and performs a second round of queries to discover
+ * cross-session evidence that the initial search missed.
+ *
+ * This is an OPTIONAL retrieval mode — an additional function callers can use
+ * when deeper search is desired. It does NOT modify the main retrieve() flow.
+ */
+
+import type { MemoryStore, MemorySearchResult } from "./store.js";
+import type { Embedder } from "./embedder.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface MultiHopConfig {
+  /** Maximum number of entity-focused follow-up queries (default: 3). */
+  maxRound2Entities: number;
+  /** Max results per round-2 query (default: 5). */
+  round2Limit: number;
+  /** Minimum score to retain in final results (default: 0.25). */
+  minScore: number;
+  /** Scope filter passed to both rounds. */
+  scopeFilter?: string[];
+  /** Round-1 result limit (default: 10). */
+  round1Limit: number;
+}
+
+export const DEFAULT_MULTI_HOP_CONFIG: MultiHopConfig = {
+  maxRound2Entities: 3,
+  round2Limit: 5,
+  minScore: 0.25,
+  round1Limit: 10,
+};
+
+export interface MultiHopResult {
+  entry: MemorySearchResult["entry"];
+  score: number;
+  /** Which round found this result ("round1" | "round2" | "both"). */
+  source: "round1" | "round2" | "both";
+}
+
+// ============================================================================
+// Stop-word list — exclude from entity extraction
+// ============================================================================
+
+const STOP_WORDS = new Set([
+  "the", "a", "an", "is", "are", "was", "were", "be", "been",
+  "have", "has", "had", "will", "would", "can", "could", "should",
+  "do", "does", "did", "not", "no", "but", "and", "or", "if",
+  "this", "that", "these", "those", "it", "its", "user", "assistant",
+  "my", "your", "his", "her", "our", "their", "i", "you", "he", "she",
+  "we", "they", "me", "him", "us", "them", "who", "what", "where",
+  "when", "how", "why", "which", "about", "with", "from", "for",
+  "into", "also", "just", "very", "some", "more", "most", "other",
+]);
+
+const CJK_STOP_RE =
+  /^(用户|助手|可以|需要|已经|没有|什么|这个|那个|因为|所以|但是|如果)$/;
+
+// ============================================================================
+// Entity extraction from retrieval results
+// ============================================================================
+
+/**
+ * Extract salient entities from memory texts.
+ * Targets: capitalized phrases, quoted terms, file paths, URLs, CJK names.
+ * Returns unique entities sorted by frequency (most common first).
+ */
+export function extractEntitiesFromTexts(texts: string[]): string[] {
+  const freq = new Map<string, number>();
+
+  for (const text of texts) {
+    // 1. Capitalized multi-word entities: "Adobe Premiere Pro", "Sony A7III"
+    const capPattern = /\b([A-Z][a-zA-Z0-9]*(?:[\s\-][A-Z][a-zA-Z0-9]*)*)\b/g;
+    let match: RegExpExecArray | null;
+    while ((match = capPattern.exec(text)) !== null) {
+      const entity = match[1].trim();
+      if (entity.length < 2 || STOP_WORDS.has(entity.toLowerCase())) continue;
+      freq.set(entity, (freq.get(entity) ?? 0) + 1);
+    }
+
+    // 2. Quoted terms: "LanceDB", 'RecallNest'
+    const quotedPattern = /["'`]([^"'`]{2,40})["'`]/g;
+    while ((match = quotedPattern.exec(text)) !== null) {
+      const entity = match[1].trim();
+      if (entity.length < 2 || STOP_WORDS.has(entity.toLowerCase())) continue;
+      freq.set(entity, (freq.get(entity) ?? 0) + 1);
+    }
+
+    // 3. File paths: /foo/bar.ts, ./src/index.ts
+    const pathPattern = /(?:\.?\/[\w\-.]+){2,}/g;
+    while ((match = pathPattern.exec(text)) !== null) {
+      const entity = match[0];
+      freq.set(entity, (freq.get(entity) ?? 0) + 1);
+    }
+
+    // 4. URLs: https://example.com/path
+    const urlPattern = /https?:\/\/[^\s)>"']+/g;
+    while ((match = urlPattern.exec(text)) !== null) {
+      const entity = match[0];
+      freq.set(entity, (freq.get(entity) ?? 0) + 1);
+    }
+
+    // 5. CJK named entities: sequences of 2-8 CJK chars
+    const cjkPattern = /([\p{Script=Han}]{2,8})/gu;
+    while ((match = cjkPattern.exec(text)) !== null) {
+      const entity = match[1];
+      if (CJK_STOP_RE.test(entity)) continue;
+      freq.set(entity, (freq.get(entity) ?? 0) + 1);
+    }
+  }
+
+  // Sort by frequency descending, then by specificity (length descending)
+  return [...freq.entries()]
+    .sort((a, b) => b[1] - a[1] || b[0].length - a[0].length)
+    .map(([entity]) => entity);
+}
+
+// ============================================================================
+// Multi-Hop Retrieval
+// ============================================================================
+
+/**
+ * Perform two-round retrieval:
+ * 1. Standard vector + BM25 search for the query.
+ * 2. Extract entities from round-1 results, run focused follow-up searches,
+ *    merge with dedup by memory ID (keep highest score).
+ *
+ * @param store   - MemoryStore instance (provides vectorSearch + bm25Search)
+ * @param embedder - Embedder instance (provides embedQuery)
+ * @param query   - The user's search query
+ * @param opts    - Optional config overrides
+ * @returns Combined results sorted by score descending
+ */
+export async function multiHopRetrieve(
+  store: MemoryStore,
+  embedder: Embedder,
+  query: string,
+  opts?: Partial<MultiHopConfig>,
+): Promise<MultiHopResult[]> {
+  const config: MultiHopConfig = { ...DEFAULT_MULTI_HOP_CONFIG, ...opts };
+
+  // ── Round 1: standard retrieval ──
+  const queryVector = await embedder.embedQuery(query);
+
+  const [vectorResults, bm25Results] = await Promise.all([
+    store.vectorSearch(queryVector, config.round1Limit, config.minScore, config.scopeFilter),
+    store.hasFtsSupport
+      ? store.bm25Search(query, config.round1Limit, config.scopeFilter)
+      : Promise.resolve([] as MemorySearchResult[]),
+  ]);
+
+  // Merge round-1 candidates by ID, keep highest score
+  const round1Map = new Map<string, MemorySearchResult>();
+  for (const r of [...vectorResults, ...bm25Results]) {
+    const existing = round1Map.get(r.entry.id);
+    if (!existing || r.score > existing.score) {
+      round1Map.set(r.entry.id, r);
+    }
+  }
+  const round1 = [...round1Map.values()]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, config.round1Limit);
+
+  if (round1.length === 0) return [];
+
+  // ── Extract entities from round-1 results ──
+  const texts = round1.map((r) => r.entry.text);
+  const allEntities = extractEntitiesFromTexts(texts);
+
+  // Remove entities that are already substrings of the query
+  const queryLower = query.toLowerCase();
+  const novelEntities = allEntities
+    .filter((e) => !queryLower.includes(e.toLowerCase()))
+    .slice(0, config.maxRound2Entities);
+
+  // If no novel entities found, return round-1 as-is
+  if (novelEntities.length === 0) {
+    return round1.map((r) => ({
+      entry: r.entry,
+      score: r.score,
+      source: "round1" as const,
+    }));
+  }
+
+  // ── Round 2: entity-focused follow-up queries ──
+  const round1Ids = new Set(round1.map((r) => r.entry.id));
+
+  const followUpPromises = novelEntities.map(async (entity) => {
+    const combinedQuery = `${entity} ${query}`;
+    const entityVector = await embedder.embedQuery(combinedQuery);
+
+    const [vRes, bRes] = await Promise.all([
+      store.vectorSearch(entityVector, config.round2Limit, config.minScore, config.scopeFilter),
+      store.hasFtsSupport
+        ? store.bm25Search(combinedQuery, config.round2Limit, config.scopeFilter)
+        : Promise.resolve([] as MemorySearchResult[]),
+    ]);
+
+    return [...vRes, ...bRes];
+  });
+
+  let round2Results: MemorySearchResult[];
+  try {
+    const batches = await Promise.all(followUpPromises);
+    round2Results = batches.flat();
+  } catch {
+    // If follow-up queries fail, gracefully return round-1 results
+    return round1.map((r) => ({
+      entry: r.entry,
+      score: r.score,
+      source: "round1" as const,
+    }));
+  }
+
+  // ── Merge round 1 + round 2, dedup by ID, keep highest score ──
+  const merged = new Map<string, MultiHopResult>();
+
+  for (const r of round1) {
+    merged.set(r.entry.id, {
+      entry: r.entry,
+      score: r.score,
+      source: "round1",
+    });
+  }
+
+  for (const r of round2Results) {
+    const existing = merged.get(r.entry.id);
+    if (!existing) {
+      merged.set(r.entry.id, {
+        entry: r.entry,
+        score: r.score,
+        source: "round2",
+      });
+    } else if (r.score > existing.score) {
+      // Found in both rounds — upgrade score and mark source
+      merged.set(r.entry.id, {
+        entry: r.entry,
+        score: r.score,
+        source: round1Ids.has(r.entry.id) ? "both" : "round2",
+      });
+    } else if (!round1Ids.has(r.entry.id)) {
+      // Already in merged from a previous round-2 batch; keep higher score
+    } else {
+      // Round-1 score was higher, but mark as "both" since it appeared in both
+      existing.source = "both";
+    }
+  }
+
+  // Sort by score descending
+  return [...merged.values()].sort((a, b) => b.score - a.score);
+}

--- a/test/multi-hop-retriever.test.mjs
+++ b/test/multi-hop-retriever.test.mjs
@@ -1,0 +1,392 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+const {
+  extractEntitiesFromTexts,
+  multiHopRetrieve,
+  DEFAULT_MULTI_HOP_CONFIG,
+} = jiti("../packages/core/src/multi-hop-retriever.ts");
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeEntry(id, text, opts = {}) {
+  return {
+    id,
+    text,
+    vector: new Array(384).fill(0.1),
+    category: opts.category ?? "fact",
+    scope: opts.scope ?? "global",
+    importance: opts.importance ?? 5,
+    timestamp: opts.timestamp ?? Date.now(),
+    metadata: opts.metadata ?? "{}",
+  };
+}
+
+/**
+ * Create a mock store.
+ * vectorResults / bm25Results are arrays returned from each search.
+ * Supports per-call override via callIndex tracking.
+ */
+function createMockStore(opts = {}) {
+  const vectorCalls = [];
+  const bm25Calls = [];
+  let vectorCallIndex = 0;
+  let bm25CallIndex = 0;
+
+  // vectorResultSets: array of result arrays, one per call
+  const vectorResultSets = opts.vectorResultSets ?? [opts.vectorResults ?? []];
+  const bm25ResultSets = opts.bm25ResultSets ?? [opts.bm25Results ?? []];
+
+  return {
+    hasFtsSupport: opts.hasFtsSupport ?? true,
+    vectorCalls,
+    bm25Calls,
+    async vectorSearch(vector, limit, minScore, scopeFilter) {
+      vectorCalls.push({ vector, limit, minScore, scopeFilter });
+      const idx = Math.min(vectorCallIndex, vectorResultSets.length - 1);
+      vectorCallIndex++;
+      return vectorResultSets[idx].slice(0, limit);
+    },
+    async bm25Search(query, limit, scopeFilter) {
+      bm25Calls.push({ query, limit, scopeFilter });
+      const idx = Math.min(bm25CallIndex, bm25ResultSets.length - 1);
+      bm25CallIndex++;
+      return bm25ResultSets[idx].slice(0, limit);
+    },
+  };
+}
+
+function createMockEmbedder(opts = {}) {
+  const calls = [];
+  return {
+    calls,
+    async embedQuery(text) {
+      calls.push(text);
+      return new Array(opts.dim ?? 384).fill(0.1);
+    },
+  };
+}
+
+// ============================================================================
+// extractEntitiesFromTexts
+// ============================================================================
+
+describe("extractEntitiesFromTexts", () => {
+  it("should extract capitalized entities", () => {
+    const entities = extractEntitiesFromTexts([
+      "Alice uses LanceDB for vector storage",
+      "Bob prefers LanceDB over Pinecone",
+    ]);
+    assert.ok(entities.includes("Alice"), "should find Alice");
+    assert.ok(entities.includes("LanceDB"), "should find LanceDB");
+    assert.ok(entities.includes("Bob"), "should find Bob");
+    assert.ok(entities.includes("Pinecone"), "should find Pinecone");
+  });
+
+  it("should extract quoted terms", () => {
+    const entities = extractEntitiesFromTexts([
+      'The project uses "memory-lancedb-pro" as the core engine',
+    ]);
+    assert.ok(
+      entities.includes("memory-lancedb-pro"),
+      "should find quoted term",
+    );
+  });
+
+  it("should extract file paths", () => {
+    const entities = extractEntitiesFromTexts([
+      "Edit the file at /src/retriever.ts to add multi-hop",
+      "Also check ./packages/core/src/store.ts",
+    ]);
+    assert.ok(
+      entities.some((e) => e.includes("/src/retriever.ts")),
+      "should find absolute path",
+    );
+    assert.ok(
+      entities.some((e) => e.includes("./packages/core")),
+      "should find relative path",
+    );
+  });
+
+  it("should extract URLs", () => {
+    const entities = extractEntitiesFromTexts([
+      "See https://github.com/win4r/UltraMemory for the repo",
+    ]);
+    assert.ok(
+      entities.some((e) => e.startsWith("https://github.com")),
+      "should find URL",
+    );
+  });
+
+  it("should extract CJK entities and filter CJK stop words", () => {
+    // CJK regex captures 2-8 consecutive Han characters as a single token.
+    // Use natural separators (punctuation, Latin chars) to create boundaries.
+    const entities = extractEntitiesFromTexts([
+      "用户 张三 提交了 LanceDB 的配置",
+      "因为 需要 更新",
+    ]);
+    assert.ok(entities.includes("张三"), "should find CJK name with boundary");
+    // Stop words that appear as standalone 2-char tokens should be filtered
+    assert.ok(!entities.includes("用户"), "should filter CJK stop word 用户");
+    assert.ok(!entities.includes("因为"), "should filter CJK stop word 因为");
+    assert.ok(!entities.includes("需要"), "should filter CJK stop word 需要");
+    // Non-stop CJK tokens should be kept
+    assert.ok(entities.includes("LanceDB"), "should find Latin entity in mixed text");
+  });
+
+  it("should filter English stop words", () => {
+    const entities = extractEntitiesFromTexts(["The user was very happy"]);
+    assert.ok(!entities.includes("The"), "should filter stop word 'The'");
+  });
+
+  it("should sort by frequency descending", () => {
+    const entities = extractEntitiesFromTexts([
+      "LanceDB is great. Alice likes LanceDB. Bob likes LanceDB too.",
+      "Alice also uses Pinecone.",
+    ]);
+    // LanceDB appears 3 times, Alice 2 times
+    assert.equal(entities[0], "LanceDB", "most frequent entity first");
+  });
+
+  it("should return empty for empty input", () => {
+    assert.deepEqual(extractEntitiesFromTexts([]), []);
+    assert.deepEqual(extractEntitiesFromTexts([""]), []);
+  });
+});
+
+// ============================================================================
+// multiHopRetrieve
+// ============================================================================
+
+describe("multiHopRetrieve", () => {
+  it("should return empty array when round-1 finds nothing", async () => {
+    const store = createMockStore({
+      vectorResults: [],
+      bm25Results: [],
+    });
+    const embedder = createMockEmbedder();
+
+    const results = await multiHopRetrieve(store, embedder, "nothing here");
+    assert.deepEqual(results, []);
+  });
+
+  it("should return round-1 results when no novel entities found", async () => {
+    // Query already contains the entity name, so no novel entities
+    const entry = makeEntry("1", "LanceDB vector storage engine");
+    const store = createMockStore({
+      vectorResults: [{ entry, score: 0.9 }],
+      bm25Results: [],
+    });
+    const embedder = createMockEmbedder();
+
+    const results = await multiHopRetrieve(
+      store,
+      embedder,
+      "LanceDB storage",
+    );
+    assert.equal(results.length, 1);
+    assert.equal(results[0].entry.id, "1");
+    assert.equal(results[0].source, "round1");
+  });
+
+  it("should perform round-2 queries for novel entities", async () => {
+    const entry1 = makeEntry("1", "Alice prefers PostgreSQL for metadata");
+    const entry2 = makeEntry(
+      "2",
+      "PostgreSQL configuration for production use",
+    );
+
+    const store = createMockStore({
+      // Round 1: returns entry1
+      vectorResultSets: [
+        [{ entry: entry1, score: 0.85 }],
+        // Round 2: returns entry2 (new finding)
+        [{ entry: entry2, score: 0.75 }],
+      ],
+      bm25ResultSets: [[], []],
+    });
+    const embedder = createMockEmbedder();
+
+    const results = await multiHopRetrieve(store, embedder, "database setup");
+    assert.ok(results.length >= 2, "should have results from both rounds");
+
+    const ids = results.map((r) => r.entry.id);
+    assert.ok(ids.includes("1"), "should include round-1 result");
+    assert.ok(ids.includes("2"), "should include round-2 result");
+  });
+
+  it("should deduplicate by ID across rounds (keep higher score)", async () => {
+    const entry = makeEntry("1", "Alice uses LanceDB for retrieval");
+
+    const store = createMockStore({
+      // Round 1: lower score
+      vectorResultSets: [
+        [{ entry, score: 0.6 }],
+        // Round 2: higher score for same entry
+        [{ entry, score: 0.9 }],
+      ],
+      bm25ResultSets: [[], []],
+    });
+    const embedder = createMockEmbedder();
+
+    const results = await multiHopRetrieve(store, embedder, "retrieval");
+    // Should appear once with the higher score and "both" source
+    const matches = results.filter((r) => r.entry.id === "1");
+    assert.equal(matches.length, 1, "should deduplicate");
+    assert.equal(matches[0].score, 0.9, "should keep higher score");
+    assert.equal(matches[0].source, "both", "should mark as both");
+  });
+
+  it("should mark source correctly for round-2-only results", async () => {
+    const entry1 = makeEntry("1", "Alice prefers PostgreSQL");
+    const entry2 = makeEntry("2", "PostgreSQL cluster setup guide");
+
+    const store = createMockStore({
+      vectorResultSets: [
+        [{ entry: entry1, score: 0.8 }],
+        [{ entry: entry2, score: 0.7 }],
+      ],
+      bm25ResultSets: [[], []],
+    });
+    const embedder = createMockEmbedder();
+
+    const results = await multiHopRetrieve(store, embedder, "database");
+    const r2Only = results.find((r) => r.entry.id === "2");
+    assert.ok(r2Only, "should find round-2 result");
+    assert.equal(r2Only.source, "round2", "should be marked round2");
+  });
+
+  it("should respect maxRound2Entities config", async () => {
+    const entry = makeEntry(
+      "1",
+      "Alice and Bob and Charlie and Diana and Eve discussed the project",
+    );
+
+    const store = createMockStore({
+      vectorResultSets: [[{ entry, score: 0.8 }], [], []],
+      bm25ResultSets: [[], [], []],
+    });
+    const embedder = createMockEmbedder();
+
+    await multiHopRetrieve(store, embedder, "discussion", {
+      maxRound2Entities: 2,
+    });
+
+    // Round 1 = 1 embedQuery call, then at most 2 entity calls
+    // Each entity call = 1 embedQuery
+    assert.ok(
+      embedder.calls.length <= 3,
+      "should make at most 3 embed calls (1 round-1 + 2 entity), got " +
+        embedder.calls.length,
+    );
+  });
+
+  it("should pass scopeFilter to both rounds", async () => {
+    const entry = makeEntry("1", "Alice uses LanceDB", {
+      scope: "proj:test",
+    });
+
+    const store = createMockStore({
+      vectorResultSets: [
+        [{ entry, score: 0.8 }],
+        [{ entry, score: 0.7 }],
+      ],
+      bm25ResultSets: [[], []],
+    });
+    const embedder = createMockEmbedder();
+
+    await multiHopRetrieve(store, embedder, "database", {
+      scopeFilter: ["proj:test"],
+    });
+
+    // All vectorSearch calls should have the scope filter
+    for (const call of store.vectorCalls) {
+      assert.deepEqual(call.scopeFilter, ["proj:test"]);
+    }
+  });
+
+  it("should skip bm25 when FTS not supported", async () => {
+    const entry = makeEntry("1", "Alice uses PostgreSQL");
+
+    const store = createMockStore({
+      hasFtsSupport: false,
+      vectorResultSets: [[{ entry, score: 0.8 }], []],
+      bm25ResultSets: [[], []],
+    });
+    const embedder = createMockEmbedder();
+
+    const results = await multiHopRetrieve(store, embedder, "database");
+    assert.equal(store.bm25Calls.length, 0, "should not call bm25Search");
+    assert.ok(results.length >= 1, "should still return vector results");
+  });
+
+  it("should gracefully handle round-2 failures", async () => {
+    const entry = makeEntry("1", "Alice uses PostgreSQL");
+    let callCount = 0;
+
+    const store = {
+      hasFtsSupport: true,
+      async vectorSearch() {
+        callCount++;
+        if (callCount === 1) {
+          return [{ entry, score: 0.8 }];
+        }
+        throw new Error("simulated failure");
+      },
+      async bm25Search() {
+        return [];
+      },
+    };
+    const embedder = createMockEmbedder();
+
+    const results = await multiHopRetrieve(store, embedder, "database");
+    // Should still return round-1 results despite round-2 failure
+    assert.ok(results.length >= 1, "should return round-1 results on failure");
+    assert.equal(results[0].source, "round1");
+  });
+
+  it("should sort final results by score descending", async () => {
+    const entry1 = makeEntry("1", "Alice uses LanceDB for production");
+    const entry2 = makeEntry(
+      "2",
+      "LanceDB benchmark results show high throughput",
+    );
+    const entry3 = makeEntry(
+      "3",
+      "Production database monitoring setup guide",
+    );
+
+    const store = createMockStore({
+      vectorResultSets: [
+        [
+          { entry: entry1, score: 0.7 },
+          { entry: entry2, score: 0.9 },
+        ],
+        [{ entry: entry3, score: 0.5 }],
+      ],
+      bm25ResultSets: [[], []],
+    });
+    const embedder = createMockEmbedder();
+
+    const results = await multiHopRetrieve(store, embedder, "database");
+    for (let i = 1; i < results.length; i++) {
+      assert.ok(
+        results[i - 1].score >= results[i].score,
+        "results[" +
+          (i - 1) +
+          "].score (" +
+          results[i - 1].score +
+          ") >= results[" +
+          i +
+          "].score (" +
+          results[i].score +
+          ")",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Port two-round (multi-hop) retrieval from RecallNest LME-5
- After initial vector+BM25 search, extracts entities from round-1 results (capitalized phrases, quoted terms, file paths, URLs, CJK names) and runs focused follow-up queries
- Discovers cross-session evidence that single-round retrieval misses
- Implemented as standalone `multiHopRetrieve()` function — does NOT modify existing `retrieve()` flow
- Configurable: `maxRound2Entities` (default 3), `round2Limit` (default 5), `round1Limit`, `minScore`, `scopeFilter`

### Files changed
- `packages/core/src/multi-hop-retriever.ts` — new module with `multiHopRetrieve()`, `extractEntitiesFromTexts()`, types, and defaults
- `packages/core/src/index.ts` — re-export multi-hop-retriever
- `test/multi-hop-retriever.test.mjs` — 18 tests covering entity extraction and retrieval logic

## Test plan
- [x] `extractEntitiesFromTexts` — capitalized entities, quoted terms, file paths, URLs, CJK entities, stop word filtering, frequency sorting, empty input
- [x] `multiHopRetrieve` — empty round-1, no novel entities, round-2 entity queries, dedup across rounds, source tagging (round1/round2/both), maxRound2Entities config, scopeFilter propagation, FTS fallback, round-2 failure graceful degradation, score sorting
- [x] All 18 tests passing with `node --test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)