### PR TITLE
feat: add temporal query filter for date-range retrieval

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,10 @@ export * from "./embedder.js";
 // Retrieval
 export * from "./retriever.js";
 
+// Temporal query parsing
+export { parseTemporalQuery, matchesTemporalFilter, applyTemporalFilter } from "./temporal-parser.js";
+export type { TemporalFilter } from "./temporal-parser.js";
+
 // Scopes
 export * from "./scopes.js";
 

--- a/packages/core/src/retriever.ts
+++ b/packages/core/src/retriever.ts
@@ -25,6 +25,7 @@ import {
   toLifecycleMemory,
   type ScoringTrace,
 } from "./smart-metadata.js";
+import { parseTemporalQuery, applyTemporalFilter } from "./temporal-parser.js";
 
 // ============================================================================
 // Types & Configuration
@@ -658,11 +659,15 @@ export class MemoryRetriever {
     const { query, limit, scopeFilter, category, source, debug, graph } = context;
     const safeLimit = clampInt(limit, 1, 20);
 
+    // ── Temporal filter extraction ──
+    const temporalFilter = parseTemporalQuery(query);
+    const searchQuery = temporalFilter.anchor ? temporalFilter.cleanedQuery : query;
+
     // ── Query understanding layer (lightweight heuristic) ──
-    const queryType = classifyQuery(query);
+    const queryType = classifyQuery(searchQuery);
     const effectiveQuery = queryType === "temporal"
-      ? expandTemporalQuery(query)
-      : query;
+      ? expandTemporalQuery(searchQuery)
+      : searchQuery;
 
     // Apply query-type-aware weight adjustments into a LOCAL copy so
     // concurrent retrieve() calls never corrupt each other's config.
@@ -702,6 +707,10 @@ export class MemoryRetriever {
         graph,
       );
     }
+
+    // ── Apply temporal post-filter ──
+    results = applyTemporalFilter(results, temporalFilter);
+    if (results.length > safeLimit) results = results.slice(0, safeLimit);
 
     // Stamp queryType on every result and finalize scoringTrace
     results = results.map((r) => {

--- a/packages/core/src/temporal-parser.ts
+++ b/packages/core/src/temporal-parser.ts
@@ -1,0 +1,429 @@
+/**
+ * Temporal Query Filters
+ *
+ * Parses date expressions from queries (e.g. "after 2024-01", "last week",
+ * "yesterday", "去年", "上个月") and converts them to date range filters
+ * for post-retrieval filtering.
+ *
+ * Design: rule-based (zero LLM calls), bilingual (EN + ZH).
+ * Falls back gracefully — if no time expression detected, returns unchanged query.
+ *
+ * Ported from RecallNest temporal-parser.ts with adaptations for UltraMemory.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface TemporalFilter {
+  /** Start of range (inclusive), undefined = unbounded */
+  after?: Date;
+  /** End of range (exclusive), undefined = unbounded */
+  before?: Date;
+  /** Original query with temporal expressions removed (for semantic search) */
+  cleanedQuery: string;
+  /** Original matched expression (for debug/trace) */
+  anchor?: string;
+}
+
+// ============================================================================
+// Date Helpers
+// ============================================================================
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+function endOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1);
+}
+
+function startOfMonth(year: number, month: number): Date {
+  return new Date(year, month, 1);
+}
+
+function endOfMonth(year: number, month: number): Date {
+  return new Date(year, month + 1, 1);
+}
+
+function startOfYear(year: number): Date {
+  return new Date(year, 0, 1);
+}
+
+function endOfYear(year: number): Date {
+  return new Date(year + 1, 0, 1);
+}
+
+function daysAgo(n: number, ref: Date): Date {
+  const d = new Date(ref);
+  d.setDate(d.getDate() - n);
+  return startOfDay(d);
+}
+
+// ============================================================================
+// Month Mapping
+// ============================================================================
+
+const MONTH_EN: Record<string, number> = {
+  january: 0, february: 1, march: 2, april: 3, may: 4, june: 5,
+  july: 6, august: 7, september: 8, october: 9, november: 10, december: 11,
+  jan: 0, feb: 1, mar: 2, apr: 3, jun: 5, jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11,
+};
+
+const MONTH_ZH: Record<string, number> = {
+  "\u4e00": 0, "\u4e8c": 1, "\u4e09": 2, "\u56db": 3, "\u4e94": 4, "\u516d": 5,
+  "\u4e03": 6, "\u516b": 7, "\u4e5d": 8, "\u5341": 9, "\u5341\u4e00": 10, "\u5341\u4e8c": 11,
+};
+
+// ============================================================================
+// Pattern Definitions (ordered by specificity — most specific first)
+// ============================================================================
+
+interface PatternDef {
+  pattern: RegExp;
+  handler: (m: RegExpMatchArray, now: Date) => { after?: Date; before?: Date; anchor: string } | null;
+}
+
+const PATTERNS: PatternDef[] = [
+  // -- Explicit operator syntax: after:YYYY-MM-DD or after:YYYY-MM --
+  {
+    pattern: /after:(\d{4})-(\d{1,2})(?:-(\d{1,2}))?/i,
+    handler: (m) => {
+      const year = parseInt(m[1], 10);
+      const month = parseInt(m[2], 10) - 1;
+      const day = m[3] ? parseInt(m[3], 10) : 1;
+      return { after: new Date(year, month, day), anchor: m[0] };
+    },
+  },
+  {
+    pattern: /before:(\d{4})-(\d{1,2})(?:-(\d{1,2}))?/i,
+    handler: (m) => {
+      const year = parseInt(m[1], 10);
+      const month = parseInt(m[2], 10) - 1;
+      if (m[3]) {
+        const day = parseInt(m[3], 10);
+        return { before: new Date(year, month, day + 1), anchor: m[0] };
+      }
+      return { before: endOfMonth(year, month), anchor: m[0] };
+    },
+  },
+
+  // -- Absolute: YYYY-MM-DD (ISO date) --
+  {
+    pattern: /\b(\d{4})-(\d{2})-(\d{2})\b/,
+    handler: (m) => {
+      const year = parseInt(m[1], 10);
+      const month = parseInt(m[2], 10) - 1;
+      const day = parseInt(m[3], 10);
+      const d = new Date(year, month, day);
+      return { after: startOfDay(d), before: endOfDay(d), anchor: m[0] };
+    },
+  },
+
+  // -- Absolute year+month (ZH): "2023\u5e74\u4e09\u6708" / "2023\u5e746\u6708" --
+  {
+    pattern: /(\d{4})\u5e74((?:\u5341\u4e00|\u5341\u4e8c|[\u4e00\u4e8c\u4e09\u56db\u4e94\u516d\u4e03\u516b\u4e5d\u5341])\u6708|\d{1,2}\u6708)/,
+    handler: (m) => {
+      const year = parseInt(m[1], 10);
+      const monthStr = m[2].replace("\u6708", "");
+      let month: number;
+      if (/^\d+$/.test(monthStr)) {
+        month = parseInt(monthStr, 10) - 1;
+      } else {
+        month = MONTH_ZH[monthStr] ?? -1;
+      }
+      if (month < 0 || month > 11) return null;
+      return {
+        after: startOfMonth(year, month),
+        before: endOfMonth(year, month),
+        anchor: m[0],
+      };
+    },
+  },
+
+  // -- Absolute year+month (EN): "March 2023" / "in March 2023" --
+  {
+    pattern: /\b(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\s+(\d{4})\b/i,
+    handler: (m) => {
+      const month = MONTH_EN[m[1].toLowerCase()];
+      const year = parseInt(m[2], 10);
+      if (month === undefined) return null;
+      return {
+        after: startOfMonth(year, month),
+        before: endOfMonth(year, month),
+        anchor: m[0],
+      };
+    },
+  },
+
+  // -- "since March" / "after March" (month in current year) --
+  {
+    pattern: /\b(?:since|after)\s+(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\b/i,
+    handler: (m, now) => {
+      const month = MONTH_EN[m[1].toLowerCase()];
+      if (month === undefined) return null;
+      return {
+        after: startOfMonth(now.getFullYear(), month),
+        anchor: m[0],
+      };
+    },
+  },
+
+  // -- Absolute year (ZH): "2023\u5e74" (standalone, not followed by month) --
+  {
+    pattern: /(\d{4})\u5e74(?:\u7684)?/,
+    handler: (m) => {
+      const year = parseInt(m[1], 10);
+      return {
+        after: startOfYear(year),
+        before: endOfYear(year),
+        anchor: m[0],
+      };
+    },
+  },
+
+  // -- "in YYYY" / "from YYYY" / "during YYYY" --
+  {
+    pattern: /\b(?:in|from|during)\s+(\d{4})\b/i,
+    handler: (m) => {
+      const year = parseInt(m[1], 10);
+      return {
+        after: startOfYear(year),
+        before: endOfYear(year),
+        anchor: m[0],
+      };
+    },
+  },
+
+  // -- Relative: "\u6700\u8fd1N\u5929/\u5468/\u6708" --
+  {
+    pattern: /\u6700\u8fd1(\d+)\s*(\u5929|\u5468|\u6708|\u4e2a\u6708)/,
+    handler: (m, now) => {
+      const n = parseInt(m[1], 10);
+      let days: number;
+      switch (m[2]) {
+        case "\u5929": days = n; break;
+        case "\u5468": days = n * 7; break;
+        case "\u6708": case "\u4e2a\u6708": days = n * 30; break;
+        default: days = n;
+      }
+      return { after: daysAgo(days, now), before: endOfDay(now), anchor: m[0] };
+    },
+  },
+
+  // -- Relative: "last N days/weeks/months" --
+  {
+    pattern: /\blast\s+(\d+)\s*(days?|weeks?|months?)\b/i,
+    handler: (m, now) => {
+      const n = parseInt(m[1], 10);
+      let days: number;
+      if (/week/i.test(m[2])) days = n * 7;
+      else if (/month/i.test(m[2])) days = n * 30;
+      else days = n;
+      return { after: daysAgo(days, now), before: endOfDay(now), anchor: m[0] };
+    },
+  },
+
+  // -- "today" / "\u4eca\u5929" --
+  {
+    pattern: /\b(today)\b|\u4eca\u5929/i,
+    handler: (m, now) => {
+      return { after: startOfDay(now), before: endOfDay(now), anchor: m[0] };
+    },
+  },
+
+  // -- "yesterday" / "\u6628\u5929" --
+  {
+    pattern: /\b(yesterday)\b|\u6628\u5929/i,
+    handler: (m, now) => {
+      const y = daysAgo(1, now);
+      return { after: y, before: endOfDay(y), anchor: m[0] };
+    },
+  },
+
+  // -- "this week" / "\u672c\u5468" / "\u8fd9\u5468" --
+  {
+    pattern: /\b(this week)\b|\u672c\u5468|\u8fd9\u5468/i,
+    handler: (m, now) => {
+      const dayOfWeek = now.getDay();
+      const mondayOffset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+      return { after: daysAgo(mondayOffset, now), before: endOfDay(now), anchor: m[0] };
+    },
+  },
+
+  // -- "this month" / "\u672c\u6708" / "\u8fd9\u4e2a\u6708" --
+  {
+    pattern: /\b(this month)\b|\u672c\u6708|\u8fd9\u4e2a\u6708/i,
+    handler: (m, now) => {
+      return {
+        after: startOfMonth(now.getFullYear(), now.getMonth()),
+        before: endOfDay(now),
+        anchor: m[0],
+      };
+    },
+  },
+
+  // -- "this year" / "\u4eca\u5e74" --
+  {
+    pattern: /\b(this year)\b|\u4eca\u5e74/i,
+    handler: (m, now) => {
+      return {
+        after: startOfYear(now.getFullYear()),
+        before: endOfDay(now),
+        anchor: m[0],
+      };
+    },
+  },
+
+  // -- Relative: "\u53bb\u5e74N\u6708" (must come before standalone \u53bb\u5e74) --
+  {
+    pattern: /\u53bb\u5e74(\d{1,2})\u6708/,
+    handler: (m, now) => {
+      const month = parseInt(m[1], 10) - 1;
+      const year = now.getFullYear() - 1;
+      return {
+        after: startOfMonth(year, month),
+        before: endOfMonth(year, month),
+        anchor: m[0],
+      };
+    },
+  },
+
+  // -- "\u4e0a\u4e2a\u6708N\u53f7" --
+  {
+    pattern: /\u4e0a\u4e2a\u6708(\d{1,2})[\u53f7\u65e5]/,
+    handler: (m, now) => {
+      const day = parseInt(m[1], 10);
+      const year = now.getFullYear();
+      const month = now.getMonth() - 1;
+      const d = new Date(year, month, day);
+      return { after: startOfDay(d), before: endOfDay(d), anchor: m[0] };
+    },
+  },
+
+  // -- Relative: "\u4e0a\u5468/\u4e0a\u4e2a\u6708/\u53bb\u5e74/\u524d\u5e74/\u5927\u524d\u5e74" --
+  {
+    pattern: /(\u4e0a\u5468|\u4e0a\u4e2a\u6708|\u53bb\u5e74|\u524d\u5e74|\u5927\u524d\u5e74)/,
+    handler: (m, now) => {
+      const year = now.getFullYear();
+      const month = now.getMonth();
+      switch (m[1]) {
+        case "\u4e0a\u5468": {
+          const dayOfWeek = now.getDay();
+          const mondayOffset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+          return { after: daysAgo(mondayOffset + 7, now), before: daysAgo(mondayOffset, now), anchor: m[0] };
+        }
+        case "\u4e0a\u4e2a\u6708":
+          return { after: startOfMonth(year, month - 1), before: endOfMonth(year, month - 1), anchor: m[0] };
+        case "\u53bb\u5e74":
+          return { after: startOfYear(year - 1), before: endOfYear(year - 1), anchor: m[0] };
+        case "\u524d\u5e74":
+          return { after: startOfYear(year - 2), before: endOfYear(year - 2), anchor: m[0] };
+        case "\u5927\u524d\u5e74":
+          return { after: startOfYear(year - 3), before: endOfYear(year - 3), anchor: m[0] };
+        default:
+          return null;
+      }
+    },
+  },
+
+  // -- "last week/month/year" --
+  {
+    pattern: /\blast\s+(week|month|year)\b/i,
+    handler: (m, now) => {
+      const year = now.getFullYear();
+      const month = now.getMonth();
+      switch (m[1].toLowerCase()) {
+        case "week": {
+          const dayOfWeek = now.getDay();
+          const mondayOffset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+          return { after: daysAgo(mondayOffset + 7, now), before: daysAgo(mondayOffset, now), anchor: m[0] };
+        }
+        case "month":
+          return { after: startOfMonth(year, month - 1), before: endOfMonth(year, month - 1), anchor: m[0] };
+        case "year":
+          return { after: startOfYear(year - 1), before: endOfYear(year - 1), anchor: m[0] };
+        default:
+          return null;
+      }
+    },
+  },
+
+  // -- "N days/weeks/months ago" --
+  {
+    pattern: /\b(\d+)\s*(days?|weeks?|months?)\s*ago\b/i,
+    handler: (m, now) => {
+      const n = parseInt(m[1], 10);
+      let days: number;
+      if (/week/i.test(m[2])) days = n * 7;
+      else if (/month/i.test(m[2])) days = n * 30;
+      else days = n;
+      const target = daysAgo(days, now);
+      return { after: target, before: endOfDay(target), anchor: m[0] };
+    },
+  },
+];
+
+// ============================================================================
+// Main Parser
+// ============================================================================
+
+/**
+ * Parse a query string for temporal expressions and extract date range filters.
+ * Returns `{ after, before, cleanedQuery }`.
+ *
+ * If no temporal expression is detected, `after` and `before` are both undefined
+ * and `cleanedQuery` equals the original query.
+ *
+ * @param query - The raw search query
+ * @param now   - Reference date (defaults to current time; pass explicit Date for testing)
+ */
+export function parseTemporalQuery(query: string, now?: Date): TemporalFilter {
+  const ref = now ?? new Date();
+  for (const { pattern, handler } of PATTERNS) {
+    const match = query.match(pattern);
+    if (match) {
+      const result = handler(match, ref);
+      if (result && (result.after || result.before)) {
+        const cleanedQuery = query
+          .replace(match[0], "")
+          .replace(/\s+/g, " ")
+          .trim();
+        return {
+          after: result.after,
+          before: result.before,
+          cleanedQuery: cleanedQuery || query,
+          anchor: result.anchor,
+        };
+      }
+    }
+  }
+  return { cleanedQuery: query };
+}
+
+// ============================================================================
+// Post-Retrieval Filter
+// ============================================================================
+
+/**
+ * Check whether a Unix-ms timestamp falls within a temporal filter range.
+ * Returns true if the timestamp satisfies the filter (or if the filter has no bounds).
+ */
+export function matchesTemporalFilter(timestampMs: number, filter: TemporalFilter): boolean {
+  if (filter.after && timestampMs < filter.after.getTime()) return false;
+  if (filter.before && timestampMs >= filter.before.getTime()) return false;
+  return true;
+}
+
+/**
+ * Filter an array of retrieval results by temporal range.
+ * Each result must have `entry.timestamp` (Unix ms).
+ * Results outside the range are removed; order is preserved.
+ */
+export function applyTemporalFilter<T extends { entry: { timestamp: number } }>(
+  results: T[],
+  filter: TemporalFilter,
+): T[] {
+  if (!filter.after && !filter.before) return results;
+  return results.filter((r) => matchesTemporalFilter(r.entry.timestamp, filter));
+}

--- a/test/temporal-parser.test.mjs
+++ b/test/temporal-parser.test.mjs
@@ -1,0 +1,398 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+const {
+  parseTemporalQuery,
+  matchesTemporalFilter,
+  applyTemporalFilter,
+} = jiti("../packages/core/src/temporal-parser.ts");
+
+// Fixed reference date for deterministic tests: 2025-06-15 12:00:00 UTC
+const REF = new Date(2025, 5, 15, 12, 0, 0);
+
+// ============================================================================
+// parseTemporalQuery — Explicit operator syntax
+// ============================================================================
+
+describe("parseTemporalQuery - explicit operators", () => {
+  it("parses after:YYYY-MM", () => {
+    const r = parseTemporalQuery("meetings after:2024-03", REF);
+    assert.ok(r.after);
+    assert.equal(r.after.getFullYear(), 2024);
+    assert.equal(r.after.getMonth(), 2); // March = 2
+    assert.equal(r.after.getDate(), 1);
+    assert.equal(r.before, undefined);
+    assert.equal(r.cleanedQuery, "meetings");
+    assert.equal(r.anchor, "after:2024-03");
+  });
+
+  it("parses before:YYYY-MM-DD", () => {
+    const r = parseTemporalQuery("projects before:2024-06-15", REF);
+    assert.ok(r.before);
+    assert.equal(r.before.getFullYear(), 2024);
+    assert.equal(r.before.getMonth(), 5); // June = 5
+    assert.equal(r.before.getDate(), 16); // day+1 for exclusive end
+    assert.equal(r.after, undefined);
+    assert.equal(r.cleanedQuery, "projects");
+  });
+
+  it("parses after:YYYY-MM-DD", () => {
+    const r = parseTemporalQuery("after:2025-01-10 deployment notes", REF);
+    assert.ok(r.after);
+    assert.equal(r.after.getFullYear(), 2025);
+    assert.equal(r.after.getMonth(), 0);
+    assert.equal(r.after.getDate(), 10);
+    assert.equal(r.cleanedQuery, "deployment notes");
+  });
+});
+
+// ============================================================================
+// parseTemporalQuery — ISO date
+// ============================================================================
+
+describe("parseTemporalQuery - ISO date", () => {
+  it("parses YYYY-MM-DD as single-day range", () => {
+    const r = parseTemporalQuery("what happened on 2024-12-25", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getFullYear(), 2024);
+    assert.equal(r.after.getMonth(), 11);
+    assert.equal(r.after.getDate(), 25);
+    assert.equal(r.before.getDate(), 26);
+    assert.ok(r.cleanedQuery.includes("what happened on"));
+  });
+});
+
+// ============================================================================
+// parseTemporalQuery — English natural language
+// ============================================================================
+
+describe("parseTemporalQuery - English natural language", () => {
+  it("parses 'last week'", () => {
+    const r = parseTemporalQuery("what did we discuss last week", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.ok(r.after < r.before);
+    assert.equal(r.anchor, "last week");
+    assert.ok(r.cleanedQuery.includes("what did we discuss"));
+  });
+
+  it("parses 'last month'", () => {
+    const r = parseTemporalQuery("changes last month", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getMonth(), 4); // May (June-1)
+    assert.equal(r.cleanedQuery, "changes");
+  });
+
+  it("parses 'last year'", () => {
+    const r = parseTemporalQuery("highlights last year", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getFullYear(), 2024);
+    assert.equal(r.after.getMonth(), 0);
+    assert.equal(r.before.getFullYear(), 2025);
+  });
+
+  it("parses 'yesterday'", () => {
+    const r = parseTemporalQuery("tasks from yesterday", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getDate(), 14);
+    assert.equal(r.cleanedQuery, "tasks from");
+  });
+
+  it("parses 'today'", () => {
+    const r = parseTemporalQuery("today meetings", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getDate(), 15);
+    assert.equal(r.before.getDate(), 16);
+    assert.equal(r.cleanedQuery, "meetings");
+  });
+
+  it("parses 'this month'", () => {
+    const r = parseTemporalQuery("this month progress", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getMonth(), 5); // June
+    assert.equal(r.after.getDate(), 1);
+    assert.equal(r.cleanedQuery, "progress");
+  });
+
+  it("parses 'this year'", () => {
+    const r = parseTemporalQuery("goals this year", REF);
+    assert.ok(r.after);
+    assert.equal(r.after.getFullYear(), 2025);
+    assert.equal(r.after.getMonth(), 0);
+  });
+
+  it("parses 'in YYYY'", () => {
+    const r = parseTemporalQuery("decisions in 2024", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getFullYear(), 2024);
+    assert.equal(r.before.getFullYear(), 2025);
+    assert.equal(r.cleanedQuery, "decisions");
+  });
+
+  it("parses 'since March' (current year)", () => {
+    const r = parseTemporalQuery("PRs since March", REF);
+    assert.ok(r.after);
+    assert.equal(r.after.getFullYear(), 2025);
+    assert.equal(r.after.getMonth(), 2); // March
+    assert.equal(r.before, undefined);
+  });
+
+  it("parses 'last 7 days'", () => {
+    const r = parseTemporalQuery("commits last 7 days", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    const diffMs = r.before.getTime() - r.after.getTime();
+    const diffDays = diffMs / (24 * 60 * 60 * 1000);
+    // Should span approximately 7 days (7 + fraction of current day)
+    assert.ok(diffDays >= 7 && diffDays <= 8);
+  });
+
+  it("parses 'March 2023' (month + year)", () => {
+    const r = parseTemporalQuery("notes from March 2023", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getFullYear(), 2023);
+    assert.equal(r.after.getMonth(), 2);
+  });
+
+  it("parses '3 days ago'", () => {
+    const r = parseTemporalQuery("error logs 3 days ago", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getDate(), 12); // June 15 - 3 = June 12
+  });
+
+  it("parses 'this week'", () => {
+    const r = parseTemporalQuery("bugs this week", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    // June 15, 2025 is a Sunday, so Monday is June 9
+    assert.equal(r.after.getDate(), 9);
+  });
+});
+
+// ============================================================================
+// parseTemporalQuery — Chinese expressions
+// ============================================================================
+
+describe("parseTemporalQuery - Chinese expressions", () => {
+  it("parses '昨天'", () => {
+    const r = parseTemporalQuery("昨天的会议", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getDate(), 14);
+  });
+
+  it("parses '今天'", () => {
+    const r = parseTemporalQuery("今天讨论了什么", REF);
+    assert.ok(r.after);
+    assert.equal(r.after.getDate(), 15);
+  });
+
+  it("parses '本月'", () => {
+    const r = parseTemporalQuery("本月的进展", REF);
+    assert.ok(r.after);
+    assert.equal(r.after.getMonth(), 5);
+    assert.equal(r.after.getDate(), 1);
+  });
+
+  it("parses '今年'", () => {
+    const r = parseTemporalQuery("今年的目标", REF);
+    assert.ok(r.after);
+    assert.equal(r.after.getFullYear(), 2025);
+    assert.equal(r.after.getMonth(), 0);
+  });
+
+  it("parses '上个月'", () => {
+    const r = parseTemporalQuery("上个月的报告", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getMonth(), 4); // May
+    assert.equal(r.before.getMonth(), 5); // June 1
+  });
+
+  it("parses '去年'", () => {
+    const r = parseTemporalQuery("去年的总结", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getFullYear(), 2024);
+    assert.equal(r.before.getFullYear(), 2025);
+  });
+
+  it("parses '去年3月'", () => {
+    const r = parseTemporalQuery("去年3月的事", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getFullYear(), 2024);
+    assert.equal(r.after.getMonth(), 2); // March
+  });
+
+  it("parses '2024年三月'", () => {
+    const r = parseTemporalQuery("2024年三月的记录", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getFullYear(), 2024);
+    assert.equal(r.after.getMonth(), 2); // March
+  });
+
+  it("parses '2024年6月'", () => {
+    const r = parseTemporalQuery("2024年6月的讨论", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getFullYear(), 2024);
+    assert.equal(r.after.getMonth(), 5); // June
+  });
+
+  it("parses '最近7天'", () => {
+    const r = parseTemporalQuery("最近7天的变更", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getDate(), 8); // June 15 - 7
+  });
+
+  it("parses '最近2周'", () => {
+    const r = parseTemporalQuery("最近2周发生了什么", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getDate(), 1); // June 15 - 14
+  });
+
+  it("parses '前年'", () => {
+    const r = parseTemporalQuery("前年的项目", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.equal(r.after.getFullYear(), 2023);
+  });
+
+  it("parses '上周'", () => {
+    const r = parseTemporalQuery("上周的任务", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+    assert.ok(r.after < r.before);
+    // June 15 is Sunday; this week Monday = June 9; last week = June 2-9
+    assert.equal(r.after.getDate(), 2);
+    assert.equal(r.before.getDate(), 9);
+  });
+
+  it("parses '这周'", () => {
+    const r = parseTemporalQuery("这周的计划", REF);
+    assert.ok(r.after);
+    assert.ok(r.before);
+  });
+});
+
+// ============================================================================
+// parseTemporalQuery — No temporal expression
+// ============================================================================
+
+describe("parseTemporalQuery - no match", () => {
+  it("returns original query when no temporal expression found", () => {
+    const r = parseTemporalQuery("how to deploy", REF);
+    assert.equal(r.cleanedQuery, "how to deploy");
+    assert.equal(r.after, undefined);
+    assert.equal(r.before, undefined);
+    assert.equal(r.anchor, undefined);
+  });
+
+  it("returns original query for empty string", () => {
+    const r = parseTemporalQuery("", REF);
+    assert.equal(r.cleanedQuery, "");
+    assert.equal(r.after, undefined);
+    assert.equal(r.before, undefined);
+  });
+});
+
+// ============================================================================
+// matchesTemporalFilter
+// ============================================================================
+
+describe("matchesTemporalFilter", () => {
+  it("returns true for no-bound filter", () => {
+    assert.equal(matchesTemporalFilter(Date.now(), { cleanedQuery: "test" }), true);
+  });
+
+  it("returns false when timestamp is before 'after' bound", () => {
+    const filter = {
+      after: new Date(2024, 6, 1),
+      cleanedQuery: "test",
+    };
+    const ts = new Date(2024, 5, 15).getTime(); // June 15 < July 1
+    assert.equal(matchesTemporalFilter(ts, filter), false);
+  });
+
+  it("returns true when timestamp is after 'after' bound", () => {
+    const filter = {
+      after: new Date(2024, 6, 1),
+      cleanedQuery: "test",
+    };
+    const ts = new Date(2024, 7, 15).getTime(); // Aug 15 > July 1
+    assert.equal(matchesTemporalFilter(ts, filter), true);
+  });
+
+  it("returns false when timestamp is at or after 'before' bound (exclusive)", () => {
+    const filter = {
+      before: new Date(2024, 6, 1),
+      cleanedQuery: "test",
+    };
+    const ts = new Date(2024, 6, 1).getTime(); // exact boundary
+    assert.equal(matchesTemporalFilter(ts, filter), false);
+  });
+
+  it("respects both bounds together", () => {
+    const filter = {
+      after: new Date(2024, 0, 1),
+      before: new Date(2025, 0, 1),
+      cleanedQuery: "test",
+    };
+    assert.equal(matchesTemporalFilter(new Date(2024, 6, 1).getTime(), filter), true);
+    assert.equal(matchesTemporalFilter(new Date(2023, 11, 31).getTime(), filter), false);
+    assert.equal(matchesTemporalFilter(new Date(2025, 0, 1).getTime(), filter), false);
+  });
+});
+
+// ============================================================================
+// applyTemporalFilter
+// ============================================================================
+
+describe("applyTemporalFilter", () => {
+  const entries = [
+    { entry: { timestamp: new Date(2024, 0, 15).getTime() }, score: 0.9 },
+    { entry: { timestamp: new Date(2024, 6, 15).getTime() }, score: 0.8 },
+    { entry: { timestamp: new Date(2025, 0, 15).getTime() }, score: 0.7 },
+  ];
+
+  it("returns all entries when filter has no bounds", () => {
+    const filtered = applyTemporalFilter(entries, { cleanedQuery: "test" });
+    assert.equal(filtered.length, 3);
+  });
+
+  it("filters entries outside date range", () => {
+    const filter = {
+      after: new Date(2024, 3, 1),
+      before: new Date(2024, 11, 31),
+      cleanedQuery: "test",
+    };
+    const filtered = applyTemporalFilter(entries, filter);
+    assert.equal(filtered.length, 1);
+    assert.equal(filtered[0].score, 0.8);
+  });
+
+  it("filters with only 'after' bound", () => {
+    const filter = {
+      after: new Date(2024, 3, 1),
+      cleanedQuery: "test",
+    };
+    const filtered = applyTemporalFilter(entries, filter);
+    assert.equal(filtered.length, 2);
+  });
+});


### PR DESCRIPTION
## Summary

- Port bilingual temporal expression parser from RecallNest to UltraMemory
- Parse date expressions from queries (`after:YYYY-MM`, `before:YYYY-MM-DD`, "last week", "yesterday", "this month", "去年", "上个月", "最近7天", "2024年三月", etc.) and convert them to date range filters
- Wire into `retriever.ts` retrieve() method: temporal tokens are stripped before vector/BM25 search, then results are post-filtered by `entry.timestamp` against the parsed date range
- Export `parseTemporalQuery`, `matchesTemporalFilter`, `applyTemporalFilter`, `TemporalFilter` from `@ultramemory/core`

### New files
- `packages/core/src/temporal-parser.ts` -- pure-function parser, zero dependencies, EN + ZH support
- `test/temporal-parser.test.mjs` -- 41 tests covering explicit syntax, ISO dates, English natural language, Chinese expressions, edge cases, and the filter utility functions

### Modified files
- `packages/core/src/retriever.ts` -- import temporal parser; in `retrieve()`, parse query for temporal expressions before classification, then post-filter results by timestamp
- `packages/core/src/index.ts` -- re-export temporal parser types and functions

## Test plan

- [x] `node --test test/temporal-parser.test.mjs` -- 41/41 pass
- [x] No new build errors from `pnpm --filter @ultramemory/core build` (pre-existing errors unrelated to this PR)
- [ ] Verify temporal filtering works end-to-end with a real LanceDB store (manual test with `after:` / `before:` syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)