### PR TITLE
feat: add session distiller — three-layer conversation compression

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,6 +108,9 @@ export * from "./reflection-retry.js";
 // Session recovery
 export * from "./session-recovery.js";
 
+// Session distiller (three-layer conversation compression)
+export * from "./session-distiller.js";
+
 // Identity & preferences
 export * from "./identity-addressing.js";
 export * from "./preference-slots.js";

--- a/packages/core/src/session-distiller.ts
+++ b/packages/core/src/session-distiller.ts
@@ -1,0 +1,549 @@
+/**
+ * Session Distiller — three-layer session distillation system
+ *
+ * Compresses conversation context and extracts durable knowledge.
+ *
+ * Layer 1: Microcompact (zero cost, pure rules — clear old tool results)
+ * Layer 2: LLM structured summary (9 dimensions)
+ * Layer 3: Memory persistence (extract knowledge → IngestionPipeline)
+ *
+ * Ported from RecallNest session-distiller, adapted for UltraMemory:
+ * - Uses LlmClient.completeJson() (not chatRaw)
+ * - Uses IngestionPipeline for persistence (not persistMemory)
+ * - Uses MemoryCategory (profile/preferences/entities/events/cases/patterns)
+ */
+
+import type { LlmClient } from "./llm-client.js";
+import type { MemoryCategory } from "./memory-categories.js";
+import type { IngestionPipeline, IngestionInput } from "./ingestion-pipeline.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ConversationMessage {
+  role: "user" | "assistant" | "system";
+  content: string | ContentBlock[];
+}
+
+export interface ContentBlock {
+  type: "text" | "tool_use" | "tool_result";
+  /** tool_use / tool_result: tool name */
+  name?: string;
+  /** tool_use: tool call ID */
+  id?: string;
+  /** tool_use: input params */
+  input?: Record<string, unknown>;
+  /** tool_result: the result content */
+  content?: string;
+  /** text block content */
+  text?: string;
+  /** tool_result: the tool_use_id this result corresponds to */
+  tool_use_id?: string;
+}
+
+export interface MicrocompactResult {
+  messages: ConversationMessage[];
+  tokensFreed: number;
+  toolsCleared: number;
+}
+
+export interface SummaryDimensions {
+  userIntent: string;
+  keyConcepts: string;
+  filesAndCode: string;
+  errorsAndFixes: string;
+  problemSolving: string;
+  userQuotes: string;
+  pendingTasks: string;
+  currentWork: string;
+  suggestedNext: string;
+}
+
+export interface SummarizeResult {
+  text: string;
+  dimensions: SummaryDimensions;
+}
+
+export interface PersistResult {
+  memoriesStored: number;
+  memoriesDuplicated: number;
+  memoriesFiltered: number;
+  ids: string[];
+}
+
+export interface DistillSessionResult {
+  microcompact: {
+    tokensFreed: number;
+    toolsCleared: number;
+  };
+  summary: SummarizeResult | null;
+  persisted: PersistResult | null;
+  compactedMessages: ConversationMessage[];
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Tools whose old results can be safely cleared */
+const COMPACTABLE_TOOLS = new Set([
+  "Read",
+  "read_file",
+  "Bash",
+  "bash",
+  "Grep",
+  "grep",
+  "Glob",
+  "glob",
+  "WebSearch",
+  "web_search",
+  "WebFetch",
+  "web_fetch",
+  "Edit",
+  "edit_file",
+  "Write",
+  "write_file",
+]);
+
+const CLEARED_MARKER = "[Cleared]";
+
+const DEFAULT_KEEP_RECENT_TOOLS = 5;
+const DEFAULT_PRESERVE_RECENT = 6;
+
+// ============================================================================
+// Layer 1: Microcompact (zero cost, pure rules)
+// ============================================================================
+
+/** Estimate tokens from text: ~1 token per 4 chars, conservative. */
+function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+/**
+ * Extract text content from a message (handles both string and ContentBlock[]).
+ */
+function getMessageText(msg: ConversationMessage): string {
+  if (typeof msg.content === "string") return msg.content;
+  return msg.content
+    .map((b) => b.text || b.content || "")
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Collect all tool_use block IDs from compactable tools in message order.
+ */
+function collectCompactableToolUseIds(
+  messages: ConversationMessage[],
+): string[] {
+  const ids: string[] = [];
+  for (const msg of messages) {
+    if (typeof msg.content === "string") continue;
+    for (const block of msg.content) {
+      if (
+        block.type === "tool_use" &&
+        block.id &&
+        block.name &&
+        COMPACTABLE_TOOLS.has(block.name)
+      ) {
+        ids.push(block.id);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Layer 1: Microcompact — clear old tool results, keep recent N.
+ *
+ * Pure function. Returns a deep copy with cleared results + stats.
+ * Does NOT call LLM.
+ */
+export function microcompact(
+  messages: ConversationMessage[],
+  keepRecent = DEFAULT_KEEP_RECENT_TOOLS,
+): MicrocompactResult {
+  const toolUseIds = collectCompactableToolUseIds(messages);
+
+  // Keep the most recent N tool results
+  // Note: slice(-0) === slice(0) in JS, so handle keepRecent=0 explicitly
+  const keepSet = new Set(
+    keepRecent > 0 ? toolUseIds.slice(-keepRecent) : [],
+  );
+
+  let tokensFreed = 0;
+  let toolsCleared = 0;
+
+  // Deep copy + clear old results
+  const result: ConversationMessage[] = messages.map((msg) => {
+    if (typeof msg.content === "string") {
+      return { ...msg };
+    }
+    const newContent: ContentBlock[] = msg.content.map((block) => {
+      if (
+        block.type === "tool_result" &&
+        block.tool_use_id &&
+        !keepSet.has(block.tool_use_id) &&
+        block.content
+      ) {
+        // Check if this tool_use_id belongs to a compactable tool
+        const isCompactable = toolUseIds.includes(block.tool_use_id);
+        if (isCompactable) {
+          const freed = estimateTokens(block.content);
+          tokensFreed += freed;
+          toolsCleared++;
+          return {
+            ...block,
+            content: CLEARED_MARKER,
+          };
+        }
+      }
+      return { ...block };
+    });
+    return { ...msg, content: newContent };
+  });
+
+  return { messages: result, tokensFreed, toolsCleared };
+}
+
+// ============================================================================
+// Layer 2: LLM Structured Summary (9 dimensions)
+// ============================================================================
+
+/**
+ * Build the extraction prompt for LLM summarization.
+ * Instructs the LLM to return JSON with 9 dimension fields.
+ */
+function buildSummarizePrompt(conversationText: string): string {
+  return `You are a session distillation assistant. Compress the following conversation into a structured summary with exactly 9 dimensions.
+
+Return valid JSON only, with these exact keys:
+{
+  "userIntent": "All explicit user requests, listed completely",
+  "keyConcepts": "Technical concepts, frameworks, patterns, terminology discussed",
+  "filesAndCode": "Each file viewed or modified, with line numbers and key code snippets",
+  "errorsAndFixes": "Each error encountered, its cause, and solution",
+  "problemSolving": "Methods attempted, which succeeded/failed, and why",
+  "userQuotes": "Non-instruction user statements (preferences, opinions, style requests) — preserve verbatim",
+  "pendingTasks": "Explicitly requested but not yet completed work",
+  "currentWork": "Detailed status of work in progress at distillation time",
+  "suggestedNext": "Most reasonable next steps based on context"
+}
+
+Rules:
+- If a dimension has no relevant content, use "none"
+- Preserve file paths, URLs, port numbers, API names verbatim
+- Be concise but complete — don't omit key information
+- Output valid JSON only, no markdown fences, no explanation
+
+Conversation:
+${conversationText}`;
+}
+
+/**
+ * Parse LLM JSON response into SummaryDimensions.
+ * Falls back to empty strings for missing fields.
+ */
+function parseDimensionsFromJson(
+  raw: Record<string, unknown>,
+): SummaryDimensions {
+  const str = (key: string): string => {
+    const val = raw[key];
+    return typeof val === "string" ? val : "";
+  };
+  return {
+    userIntent: str("userIntent"),
+    keyConcepts: str("keyConcepts"),
+    filesAndCode: str("filesAndCode"),
+    errorsAndFixes: str("errorsAndFixes"),
+    problemSolving: str("problemSolving"),
+    userQuotes: str("userQuotes"),
+    pendingTasks: str("pendingTasks"),
+    currentWork: str("currentWork"),
+    suggestedNext: str("suggestedNext"),
+  };
+}
+
+/**
+ * Build a flat text from messages for LLM input.
+ */
+function flattenMessages(messages: ConversationMessage[]): string {
+  return messages
+    .map((msg) => {
+      const text = getMessageText(msg);
+      return `[${msg.role}]: ${text}`;
+    })
+    .join("\n\n");
+}
+
+/**
+ * Format dimensions into a readable summary text.
+ */
+function formatDimensionsText(dims: SummaryDimensions): string {
+  const sections: [string, string][] = [
+    ["User Intent", dims.userIntent],
+    ["Key Concepts", dims.keyConcepts],
+    ["Files & Code", dims.filesAndCode],
+    ["Errors & Fixes", dims.errorsAndFixes],
+    ["Problem Solving", dims.problemSolving],
+    ["User Quotes", dims.userQuotes],
+    ["Pending Tasks", dims.pendingTasks],
+    ["Current Work", dims.currentWork],
+    ["Suggested Next", dims.suggestedNext],
+  ];
+  return sections
+    .filter(([, content]) => content && content !== "none")
+    .map(([heading, content]) => `## ${heading}\n${content}`)
+    .join("\n\n");
+}
+
+/**
+ * Layer 2: Summarize session via LLM into 9 structured dimensions.
+ *
+ * Uses LlmClient.completeJson() since UltraMemory's LlmClient doesn't
+ * have a chatRaw method. Returns null if LLM is unavailable or fails.
+ */
+export async function summarizeSession(
+  messages: ConversationMessage[],
+  llm: LlmClient,
+  preserveRecent = DEFAULT_PRESERVE_RECENT,
+): Promise<{
+  summary: SummarizeResult;
+  compactedMessages: ConversationMessage[];
+} | null> {
+  if (messages.length <= preserveRecent) {
+    // Nothing old enough to summarize
+    return null;
+  }
+
+  const older = messages.slice(0, -preserveRecent);
+  const newer = messages.slice(-preserveRecent);
+
+  const conversationText = flattenMessages(older);
+  if (!conversationText.trim()) return null;
+
+  const prompt = buildSummarizePrompt(conversationText);
+
+  // Use completeJson — UltraMemory's LlmClient parses JSON automatically
+  const rawJson = await llm.completeJson<Record<string, unknown>>(
+    prompt,
+    "session-distill",
+  );
+  if (!rawJson) return null;
+
+  const dimensions = parseDimensionsFromJson(rawJson);
+  const text = formatDimensionsText(dimensions);
+  const summary: SummarizeResult = { text, dimensions };
+
+  // Build compacted messages: [summary as synthetic user msg] + [recent preserved]
+  const summaryMsg: ConversationMessage = {
+    role: "user",
+    content:
+      "This session continues from a previous conversation. The following summary covers the earlier portion.\n\n" +
+      text +
+      "\n\nRecent messages have been preserved as-is." +
+      "\nPlease continue from where we left off — do not ask further questions. Resume directly without confirming the summary or restating prior content.",
+  };
+
+  return {
+    summary,
+    compactedMessages: [summaryMsg, ...newer],
+  };
+}
+
+// ============================================================================
+// Layer 3: Memory Persistence (UltraMemory IngestionPipeline)
+// ============================================================================
+
+interface DimensionMapping {
+  dimension: keyof SummaryDimensions;
+  category: MemoryCategory;
+  importance: number;
+  /** Skip if content matches this */
+  skipIfEmpty: string;
+}
+
+const DIMENSION_MAPPINGS: DimensionMapping[] = [
+  {
+    dimension: "userIntent",
+    category: "events",
+    importance: 0.5,
+    skipIfEmpty: "none",
+  },
+  {
+    dimension: "errorsAndFixes",
+    category: "cases",
+    importance: 0.7,
+    skipIfEmpty: "none",
+  },
+  {
+    dimension: "problemSolving",
+    category: "patterns",
+    importance: 0.8,
+    skipIfEmpty: "none",
+  },
+  {
+    dimension: "userQuotes",
+    category: "preferences",
+    importance: 0.7,
+    skipIfEmpty: "none",
+  },
+  {
+    dimension: "filesAndCode",
+    category: "entities",
+    importance: 0.6,
+    skipIfEmpty: "none",
+  },
+];
+
+/** Min content length to bother persisting (skip trivial extractions). */
+const MIN_PERSIST_LENGTH = 20;
+
+/**
+ * Layer 3: Extract knowledge from structured summary and persist via IngestionPipeline.
+ *
+ * Uses UltraMemory's IngestionPipeline which handles dedup, conflict detection,
+ * metadata building, and multi-layer vectors.
+ */
+export async function extractAndPersist(
+  dimensions: SummaryDimensions,
+  scope: string,
+  pipeline: IngestionPipeline,
+): Promise<PersistResult> {
+  const result: PersistResult = {
+    memoriesStored: 0,
+    memoriesDuplicated: 0,
+    memoriesFiltered: 0,
+    ids: [],
+  };
+
+  for (const mapping of DIMENSION_MAPPINGS) {
+    const content = dimensions[mapping.dimension];
+    if (
+      !content ||
+      content.trim() === mapping.skipIfEmpty ||
+      content.trim().length < MIN_PERSIST_LENGTH
+    ) {
+      continue;
+    }
+
+    try {
+      const input: IngestionInput = {
+        text: content.slice(0, 4000), // Respect reasonable text limits
+        category: mapping.category,
+        importance: mapping.importance,
+        scope,
+        source: "session-summary",
+      };
+
+      const ingested = await pipeline.ingest(input);
+
+      switch (ingested.action) {
+        case "created":
+        case "superseded":
+          result.memoriesStored++;
+          result.ids.push(ingested.id);
+          break;
+        case "duplicate":
+          result.memoriesDuplicated++;
+          break;
+        case "noise_filtered":
+        case "conflict_detected":
+          result.memoriesFiltered++;
+          break;
+      }
+    } catch {
+      // Non-fatal: skip this dimension on error
+      result.memoriesFiltered++;
+    }
+  }
+
+  return result;
+}
+
+// ============================================================================
+// Orchestrator: distillSession (combines all 3 layers)
+// ============================================================================
+
+export interface DistillSessionInput {
+  messages: ConversationMessage[];
+  scope: string;
+  preserveRecent?: number;
+  keepRecentTools?: number;
+  persist?: boolean;
+}
+
+export interface DistillSessionDeps {
+  llm: LlmClient | null;
+  pipeline: IngestionPipeline | null;
+}
+
+/**
+ * Full session distillation: microcompact -> LLM summary -> persist to UltraMemory.
+ *
+ * All three layers are optional and degrade gracefully:
+ * - No LLM? Layer 1 only (still saves tokens by clearing tool results).
+ * - No pipeline? Layers 1+2 (summary without persistence).
+ * - persist=false? Same as no pipeline.
+ */
+export async function distillSession(
+  input: DistillSessionInput,
+  deps: DistillSessionDeps,
+): Promise<DistillSessionResult> {
+  const preserveRecent = input.preserveRecent ?? DEFAULT_PRESERVE_RECENT;
+  const keepRecentTools = input.keepRecentTools ?? DEFAULT_KEEP_RECENT_TOOLS;
+  const shouldPersist = input.persist !== false;
+
+  // Layer 1: Microcompact
+  const mc = microcompact(input.messages, keepRecentTools);
+
+  // Layer 2: LLM summary (if LLM available)
+  let summaryResult: {
+    summary: SummarizeResult;
+    compactedMessages: ConversationMessage[];
+  } | null = null;
+  if (deps.llm) {
+    summaryResult = await summarizeSession(
+      mc.messages,
+      deps.llm,
+      preserveRecent,
+    );
+  }
+
+  // Layer 3: Persist (if summary succeeded and persist enabled)
+  let persistResult: PersistResult | null = null;
+  if (shouldPersist && summaryResult && deps.pipeline) {
+    persistResult = await extractAndPersist(
+      summaryResult.summary.dimensions,
+      input.scope,
+      deps.pipeline,
+    );
+  }
+
+  return {
+    microcompact: {
+      tokensFreed: mc.tokensFreed,
+      toolsCleared: mc.toolsCleared,
+    },
+    summary: summaryResult?.summary ?? null,
+    persisted: persistResult,
+    compactedMessages: summaryResult?.compactedMessages ?? mc.messages,
+  };
+}
+
+// ============================================================================
+// Exported helpers (for testing)
+// ============================================================================
+
+export {
+  estimateTokens as _estimateTokens,
+  getMessageText as _getMessageText,
+  flattenMessages as _flattenMessages,
+  parseDimensionsFromJson as _parseDimensionsFromJson,
+  formatDimensionsText as _formatDimensionsText,
+  COMPACTABLE_TOOLS as _COMPACTABLE_TOOLS,
+  DIMENSION_MAPPINGS as _DIMENSION_MAPPINGS,
+  CLEARED_MARKER as _CLEARED_MARKER,
+};

--- a/test/session-distiller.test.mjs
+++ b/test/session-distiller.test.mjs
@@ -1,0 +1,624 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import Module from "node:module";
+
+process.env.NODE_PATH = [
+  process.env.NODE_PATH,
+  "/opt/homebrew/lib/node_modules/openclaw/node_modules",
+  "/opt/homebrew/lib/node_modules",
+].filter(Boolean).join(":");
+Module._initPaths();
+
+import jitiFactory from "jiti";
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+const {
+  microcompact,
+  summarizeSession,
+  extractAndPersist,
+  distillSession,
+  _estimateTokens,
+  _getMessageText,
+  _flattenMessages,
+  _parseDimensionsFromJson,
+  _formatDimensionsText,
+  _COMPACTABLE_TOOLS,
+  _DIMENSION_MAPPINGS,
+  _CLEARED_MARKER,
+} = jiti("../packages/core/src/session-distiller.ts");
+
+// ============================================================================
+// Helper factories
+// ============================================================================
+
+/** Create a simple text message */
+function textMsg(role, text) {
+  return { role, content: text };
+}
+
+/** Create a message with tool_use + tool_result blocks */
+function toolMsg(toolName, toolId, resultContent) {
+  return [
+    {
+      role: "assistant",
+      content: [
+        { type: "tool_use", name: toolName, id: toolId, input: {} },
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        { type: "tool_result", tool_use_id: toolId, content: resultContent },
+      ],
+    },
+  ];
+}
+
+/** Create a mock LlmClient that returns the given dimensions JSON */
+function mockLlm(dimensionsJson) {
+  return {
+    async completeJson(_prompt, _label) {
+      return dimensionsJson;
+    },
+    getLastError() { return null; },
+  };
+}
+
+/** Create a mock LlmClient that fails */
+function failingLlm() {
+  return {
+    async completeJson() { return null; },
+    getLastError() { return "mock error"; },
+  };
+}
+
+/** Create a mock IngestionPipeline */
+function mockPipeline(action = "created") {
+  const ingested = [];
+  let idCounter = 0;
+  return {
+    ingested,
+    async ingest(input) {
+      ingested.push(input);
+      idCounter++;
+      return { id: `mem-${idCounter}`, action, relationsAdded: 0 };
+    },
+  };
+}
+
+// ============================================================================
+// _estimateTokens
+// ============================================================================
+
+describe("estimateTokens", () => {
+  test("empty string returns 0", () => {
+    assert.equal(_estimateTokens(""), 0);
+  });
+
+  test("short string returns at least 1", () => {
+    assert.equal(_estimateTokens("hi"), 1);
+  });
+
+  test("longer string returns length/4 ceiling", () => {
+    const text = "a".repeat(100);
+    assert.equal(_estimateTokens(text), 25);
+  });
+});
+
+// ============================================================================
+// _getMessageText
+// ============================================================================
+
+describe("getMessageText", () => {
+  test("string content", () => {
+    assert.equal(_getMessageText({ role: "user", content: "hello" }), "hello");
+  });
+
+  test("ContentBlock array", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "first" },
+        { type: "text", text: "second" },
+      ],
+    };
+    assert.equal(_getMessageText(msg), "first\nsecond");
+  });
+
+  test("mixed blocks with tool_result content", () => {
+    const msg = {
+      role: "user",
+      content: [
+        { type: "tool_result", content: "result data", tool_use_id: "x" },
+        { type: "text", text: "after" },
+      ],
+    };
+    assert.equal(_getMessageText(msg), "result data\nafter");
+  });
+});
+
+// ============================================================================
+// microcompact — Layer 1
+// ============================================================================
+
+describe("microcompact", () => {
+  test("returns same messages when no tool results", () => {
+    const msgs = [textMsg("user", "hello"), textMsg("assistant", "hi")];
+    const result = microcompact(msgs);
+    assert.equal(result.tokensFreed, 0);
+    assert.equal(result.toolsCleared, 0);
+    assert.equal(result.messages.length, 2);
+    assert.equal(result.messages[0].content, "hello");
+  });
+
+  test("clears old compactable tool results, keeps recent", () => {
+    // Create 3 tool calls — with keepRecent=1, only the last should survive
+    const msgs = [
+      ...toolMsg("Read", "t1", "file content 1 that is quite long"),
+      ...toolMsg("Bash", "t2", "command output here"),
+      ...toolMsg("Read", "t3", "recent file content"),
+    ];
+
+    const result = microcompact(msgs, 1);
+    assert.equal(result.toolsCleared, 2);
+    assert.ok(result.tokensFreed > 0);
+
+    // t1 and t2 should be cleared, t3 should be preserved
+    const t1Result = result.messages[1].content.find(
+      (b) => b.tool_use_id === "t1"
+    );
+    assert.equal(t1Result.content, _CLEARED_MARKER);
+
+    const t3Result = result.messages[5].content.find(
+      (b) => b.tool_use_id === "t3"
+    );
+    assert.equal(t3Result.content, "recent file content");
+  });
+
+  test("does not clear non-compactable tool results", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", name: "CustomTool", id: "c1", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "c1", content: "custom output" },
+        ],
+      },
+    ];
+
+    const result = microcompact(msgs, 0);
+    assert.equal(result.toolsCleared, 0);
+    const resultBlock = result.messages[1].content[0];
+    assert.equal(resultBlock.content, "custom output");
+  });
+
+  test("returns deep copy — original not mutated", () => {
+    const msgs = [...toolMsg("Read", "t1", "original content")];
+    const result = microcompact(msgs, 0);
+
+    // Original should be unmodified
+    assert.equal(msgs[1].content[0].content, "original content");
+    // Result should be cleared
+    assert.equal(result.messages[1].content[0].content, _CLEARED_MARKER);
+  });
+
+  test("handles string-only messages mixed with block messages", () => {
+    const msgs = [
+      textMsg("user", "do something"),
+      ...toolMsg("Grep", "g1", "search results"),
+      textMsg("assistant", "found it"),
+    ];
+
+    const result = microcompact(msgs, 0);
+    assert.equal(result.toolsCleared, 1);
+    assert.equal(result.messages[0].content, "do something");
+    assert.equal(result.messages[3].content, "found it");
+  });
+});
+
+// ============================================================================
+// _parseDimensionsFromJson
+// ============================================================================
+
+describe("parseDimensionsFromJson", () => {
+  test("extracts all 9 dimensions from complete JSON", () => {
+    const raw = {
+      userIntent: "build a feature",
+      keyConcepts: "TypeScript, testing",
+      filesAndCode: "src/index.ts:10",
+      errorsAndFixes: "none",
+      problemSolving: "tried X, Y worked",
+      userQuotes: "I prefer concise code",
+      pendingTasks: "none",
+      currentWork: "implementing session distiller",
+      suggestedNext: "write tests",
+    };
+    const dims = _parseDimensionsFromJson(raw);
+    assert.equal(dims.userIntent, "build a feature");
+    assert.equal(dims.suggestedNext, "write tests");
+  });
+
+  test("missing fields become empty strings", () => {
+    const dims = _parseDimensionsFromJson({});
+    assert.equal(dims.userIntent, "");
+    assert.equal(dims.keyConcepts, "");
+    assert.equal(dims.filesAndCode, "");
+  });
+
+  test("non-string values become empty strings", () => {
+    const dims = _parseDimensionsFromJson({ userIntent: 42, keyConcepts: null });
+    assert.equal(dims.userIntent, "");
+    assert.equal(dims.keyConcepts, "");
+  });
+});
+
+// ============================================================================
+// _formatDimensionsText
+// ============================================================================
+
+describe("formatDimensionsText", () => {
+  test("formats non-empty dimensions with headings", () => {
+    const dims = {
+      userIntent: "build X",
+      keyConcepts: "none",
+      filesAndCode: "",
+      errorsAndFixes: "none",
+      problemSolving: "",
+      userQuotes: "I like clean code",
+      pendingTasks: "none",
+      currentWork: "none",
+      suggestedNext: "write tests next",
+    };
+    const text = _formatDimensionsText(dims);
+    assert.ok(text.includes("## User Intent"));
+    assert.ok(text.includes("build X"));
+    assert.ok(text.includes("## User Quotes"));
+    assert.ok(!text.includes("## Key Concepts")); // "none" is filtered out
+    assert.ok(!text.includes("## Files & Code")); // empty is filtered out
+  });
+});
+
+// ============================================================================
+// summarizeSession — Layer 2
+// ============================================================================
+
+describe("summarizeSession", () => {
+  test("returns null when messages <= preserveRecent", async () => {
+    const msgs = [textMsg("user", "hi"), textMsg("assistant", "hello")];
+    const llm = mockLlm({});
+    const result = await summarizeSession(msgs, llm, 5);
+    assert.equal(result, null);
+  });
+
+  test("returns null when LLM returns null", async () => {
+    const msgs = Array.from({ length: 10 }, (_, i) =>
+      textMsg(i % 2 === 0 ? "user" : "assistant", `msg ${i}`)
+    );
+    const llm = failingLlm();
+    const result = await summarizeSession(msgs, llm, 3);
+    assert.equal(result, null);
+  });
+
+  test("returns summary with compacted messages on success", async () => {
+    const msgs = Array.from({ length: 10 }, (_, i) =>
+      textMsg(i % 2 === 0 ? "user" : "assistant", `message number ${i}`)
+    );
+    const llm = mockLlm({
+      userIntent: "Port session distiller",
+      keyConcepts: "TypeScript, LLM, memory",
+      filesAndCode: "session-distiller.ts",
+      errorsAndFixes: "none",
+      problemSolving: "adapted RecallNest code",
+      userQuotes: "Take care with the types",
+      pendingTasks: "none",
+      currentWork: "implementing",
+      suggestedNext: "write tests",
+    });
+
+    const result = await summarizeSession(msgs, llm, 3);
+    assert.ok(result);
+    assert.ok(result.summary);
+    assert.equal(result.summary.dimensions.userIntent, "Port session distiller");
+    // compactedMessages: 1 (summary) + 3 (preserveRecent) = 4
+    assert.equal(result.compactedMessages.length, 4);
+    assert.equal(result.compactedMessages[0].role, "user");
+    assert.ok(
+      typeof result.compactedMessages[0].content === "string" &&
+      result.compactedMessages[0].content.includes("summary")
+    );
+  });
+
+  test("preserves exactly preserveRecent recent messages", async () => {
+    const msgs = Array.from({ length: 8 }, (_, i) =>
+      textMsg(i % 2 === 0 ? "user" : "assistant", `msg-${i}`)
+    );
+    const llm = mockLlm({ userIntent: "test" });
+    const result = await summarizeSession(msgs, llm, 4);
+    assert.ok(result);
+    // 1 summary + 4 recent = 5
+    assert.equal(result.compactedMessages.length, 5);
+    // Last 4 should be the original recent messages
+    assert.equal(result.compactedMessages[4].content, "msg-7");
+  });
+});
+
+// ============================================================================
+// extractAndPersist — Layer 3
+// ============================================================================
+
+describe("extractAndPersist", () => {
+  test("persists non-trivial dimensions via pipeline", async () => {
+    const dims = {
+      userIntent: "Build a session distiller with three layers of compression for UltraMemory",
+      keyConcepts: "none",
+      filesAndCode: "none",
+      errorsAndFixes: "Fixed the import path from llm-client.js — was missing the .js extension suffix",
+      problemSolving: "Tried using chatRaw first but UltraMemory only has completeJson, adapted prompt format accordingly",
+      userQuotes: "I prefer TypeScript with strict types",
+      pendingTasks: "none",
+      currentWork: "none",
+      suggestedNext: "none",
+    };
+
+    const pipeline = mockPipeline("created");
+    const result = await extractAndPersist(dims, "test-scope", pipeline);
+
+    // userIntent, errorsAndFixes, problemSolving, userQuotes should all be persisted
+    // (filesAndCode is "none" so skipped)
+    assert.equal(result.memoriesStored, 4);
+    assert.equal(result.ids.length, 4);
+    assert.equal(pipeline.ingested.length, 4);
+
+    // Verify the scope was passed through
+    for (const entry of pipeline.ingested) {
+      assert.equal(entry.scope, "test-scope");
+      assert.equal(entry.source, "session-summary");
+    }
+  });
+
+  test("skips dimensions with 'none' content", async () => {
+    const dims = {
+      userIntent: "none",
+      keyConcepts: "none",
+      filesAndCode: "none",
+      errorsAndFixes: "none",
+      problemSolving: "none",
+      userQuotes: "none",
+      pendingTasks: "none",
+      currentWork: "none",
+      suggestedNext: "none",
+    };
+
+    const pipeline = mockPipeline("created");
+    const result = await extractAndPersist(dims, "scope", pipeline);
+    assert.equal(result.memoriesStored, 0);
+    assert.equal(pipeline.ingested.length, 0);
+  });
+
+  test("skips dimensions shorter than MIN_PERSIST_LENGTH", async () => {
+    const dims = {
+      userIntent: "short",       // < 20 chars
+      keyConcepts: "none",
+      filesAndCode: "none",
+      errorsAndFixes: "none",
+      problemSolving: "none",
+      userQuotes: "brief note",  // < 20 chars
+      pendingTasks: "none",
+      currentWork: "none",
+      suggestedNext: "none",
+    };
+
+    const pipeline = mockPipeline("created");
+    const result = await extractAndPersist(dims, "scope", pipeline);
+    assert.equal(result.memoriesStored, 0);
+    assert.equal(pipeline.ingested.length, 0);
+  });
+
+  test("counts duplicate actions correctly", async () => {
+    const dims = {
+      userIntent: "Build a large feature with many components involved",
+      keyConcepts: "none",
+      filesAndCode: "none",
+      errorsAndFixes: "none",
+      problemSolving: "none",
+      userQuotes: "I want everything to be consistent and well-tested",
+      pendingTasks: "none",
+      currentWork: "none",
+      suggestedNext: "none",
+    };
+
+    const pipeline = mockPipeline("duplicate");
+    const result = await extractAndPersist(dims, "scope", pipeline);
+    assert.equal(result.memoriesDuplicated, 2);
+    assert.equal(result.memoriesStored, 0);
+  });
+
+  test("handles pipeline errors gracefully", async () => {
+    const dims = {
+      userIntent: "This is a long enough user intent to be persisted",
+      keyConcepts: "none",
+      filesAndCode: "none",
+      errorsAndFixes: "none",
+      problemSolving: "none",
+      userQuotes: "none",
+      pendingTasks: "none",
+      currentWork: "none",
+      suggestedNext: "none",
+    };
+
+    const pipeline = {
+      async ingest() { throw new Error("store unavailable"); },
+    };
+    const result = await extractAndPersist(dims, "scope", pipeline);
+    assert.equal(result.memoriesFiltered, 1);
+    assert.equal(result.memoriesStored, 0);
+  });
+
+  test("maps dimensions to correct memory categories", async () => {
+    const dims = {
+      userIntent: "This intent is long enough to be persisted definitely",
+      keyConcepts: "none",
+      filesAndCode: "These are the files and code that were modified in detail",
+      errorsAndFixes: "Fixed the authentication error by refreshing the token properly",
+      problemSolving: "Tried approach A first but approach B worked much better in the end",
+      userQuotes: "I always prefer clear variable names over short ones",
+      pendingTasks: "none",
+      currentWork: "none",
+      suggestedNext: "none",
+    };
+
+    const pipeline = mockPipeline("created");
+    await extractAndPersist(dims, "scope", pipeline);
+
+    const categories = pipeline.ingested.map((e) => e.category);
+    assert.ok(categories.includes("events"));      // userIntent
+    assert.ok(categories.includes("cases"));        // errorsAndFixes
+    assert.ok(categories.includes("patterns"));     // problemSolving
+    assert.ok(categories.includes("preferences"));  // userQuotes
+    assert.ok(categories.includes("entities"));     // filesAndCode
+  });
+});
+
+// ============================================================================
+// distillSession — Orchestrator
+// ============================================================================
+
+describe("distillSession", () => {
+  test("layer 1 only when no LLM", async () => {
+    const msgs = [
+      textMsg("user", "do something"),
+      ...toolMsg("Read", "r1", "file content long enough"),
+      textMsg("assistant", "done"),
+    ];
+
+    const result = await distillSession(
+      { messages: msgs, scope: "test", keepRecentTools: 0 },
+      { llm: null, pipeline: null }
+    );
+
+    assert.ok(result.microcompact.toolsCleared > 0);
+    assert.equal(result.summary, null);
+    assert.equal(result.persisted, null);
+    assert.equal(result.compactedMessages.length, msgs.length);
+  });
+
+  test("layers 1+2 when LLM available but no pipeline", async () => {
+    const msgs = Array.from({ length: 10 }, (_, i) =>
+      textMsg(i % 2 === 0 ? "user" : "assistant", `message ${i}`)
+    );
+
+    const llm = mockLlm({
+      userIntent: "orchestrator test",
+      keyConcepts: "none",
+      filesAndCode: "none",
+      errorsAndFixes: "none",
+      problemSolving: "none",
+      userQuotes: "none",
+      pendingTasks: "none",
+      currentWork: "none",
+      suggestedNext: "none",
+    });
+
+    const result = await distillSession(
+      { messages: msgs, scope: "test", preserveRecent: 3 },
+      { llm, pipeline: null }
+    );
+
+    assert.ok(result.summary);
+    assert.equal(result.persisted, null);
+    // 1 summary + 3 recent
+    assert.equal(result.compactedMessages.length, 4);
+  });
+
+  test("all 3 layers when LLM + pipeline available", async () => {
+    const msgs = Array.from({ length: 10 }, (_, i) =>
+      textMsg(i % 2 === 0 ? "user" : "assistant", `long message content number ${i} with enough text`)
+    );
+
+    const llm = mockLlm({
+      userIntent: "Full distillation test with all three layers working together",
+      keyConcepts: "none",
+      filesAndCode: "none",
+      errorsAndFixes: "none",
+      problemSolving: "none",
+      userQuotes: "none",
+      pendingTasks: "none",
+      currentWork: "none",
+      suggestedNext: "none",
+    });
+
+    const pipeline = mockPipeline("created");
+
+    const result = await distillSession(
+      { messages: msgs, scope: "test-scope", preserveRecent: 3 },
+      { llm, pipeline }
+    );
+
+    assert.ok(result.summary);
+    assert.ok(result.persisted);
+    assert.equal(result.persisted.memoriesStored, 1); // only userIntent is long enough
+    assert.equal(result.compactedMessages.length, 4);
+  });
+
+  test("persist=false skips layer 3", async () => {
+    const msgs = Array.from({ length: 10 }, (_, i) =>
+      textMsg(i % 2 === 0 ? "user" : "assistant", `msg ${i}`)
+    );
+
+    const llm = mockLlm({
+      userIntent: "Should not be persisted because persist flag is false",
+      keyConcepts: "none",
+      filesAndCode: "none",
+      errorsAndFixes: "none",
+      problemSolving: "none",
+      userQuotes: "none",
+      pendingTasks: "none",
+      currentWork: "none",
+      suggestedNext: "none",
+    });
+
+    const pipeline = mockPipeline("created");
+
+    const result = await distillSession(
+      { messages: msgs, scope: "test", persist: false },
+      { llm, pipeline }
+    );
+
+    assert.ok(result.summary);
+    assert.equal(result.persisted, null);
+    assert.equal(pipeline.ingested.length, 0);
+  });
+});
+
+// ============================================================================
+// Constants sanity
+// ============================================================================
+
+describe("constants", () => {
+  test("COMPACTABLE_TOOLS contains expected tools", () => {
+    assert.ok(_COMPACTABLE_TOOLS.has("Read"));
+    assert.ok(_COMPACTABLE_TOOLS.has("Bash"));
+    assert.ok(_COMPACTABLE_TOOLS.has("Grep"));
+    assert.ok(_COMPACTABLE_TOOLS.has("Glob"));
+    assert.ok(_COMPACTABLE_TOOLS.has("Edit"));
+    assert.ok(_COMPACTABLE_TOOLS.has("Write"));
+    assert.ok(!_COMPACTABLE_TOOLS.has("CustomTool"));
+  });
+
+  test("DIMENSION_MAPPINGS cover expected categories", () => {
+    const categories = _DIMENSION_MAPPINGS.map((m) => m.category);
+    assert.ok(categories.includes("events"));
+    assert.ok(categories.includes("cases"));
+    assert.ok(categories.includes("patterns"));
+    assert.ok(categories.includes("preferences"));
+    assert.ok(categories.includes("entities"));
+  });
+
+  test("CLEARED_MARKER is [Cleared]", () => {
+    assert.equal(_CLEARED_MARKER, "[Cleared]");
+  });
+});


### PR DESCRIPTION
## Summary
- Port RecallNest's session-distiller to UltraMemory as a three-layer conversation compression system
- **Layer 1 (microcompact)**: Zero-cost, pure-logic clearing of old tool results (Read, Bash, Grep, etc.) with configurable recent-keep count. Fixes a `slice(-0)` edge case from the upstream implementation
- **Layer 2 (summarize)**: LLM-powered structured summary extracting 9 dimensions (user intent, key concepts, files/code, errors/fixes, problem solving, user quotes, pending tasks, current work, suggested next) via `LlmClient.completeJson()`
- **Layer 3 (persist)**: Maps summary dimensions to UltraMemory's 6-category system (events, cases, patterns, preferences, entities) and persists via `IngestionPipeline` with full dedup/conflict support
- **Orchestrator (`distillSession`)**: Runs all 3 layers with graceful degradation — works without LLM (layer 1 only), without pipeline (layers 1+2), or with everything

## Adaptations from RecallNest
- Uses `LlmClient.completeJson()` instead of `chatRaw()` (UltraMemory's LLM interface)
- Uses `IngestionPipeline.ingest()` instead of `persistMemory()` for full write-path integration
- Maps to UltraMemory's `MemoryCategory` (profile/preferences/entities/events/cases/patterns)
- All deps are injectable — no hard coupling to specific store or embedder implementations

## Files changed
- `packages/core/src/session-distiller.ts` — main implementation (549 lines)
- `packages/core/src/index.ts` — re-export
- `test/session-distiller.test.mjs` — 32 tests across 9 suites

## Test plan
- [x] 32 unit tests covering all 3 layers, helpers, orchestrator, and edge cases
- [x] All tests pass (`node --test test/session-distiller.test.mjs`)
- [x] No new TypeScript build errors from session-distiller.ts
- [ ] Integration test with real LlmClient + IngestionPipeline (future)

🤖 Generated with [Claude Code](https://claude.com/claude-code)