### PR TITLE
feat: add conversation import — 5-format normalizer pipeline

### DIFF
--- a/packages/core/src/conversation-importer.ts
+++ b/packages/core/src/conversation-importer.ts
@@ -1,0 +1,389 @@
+/**
+ * Conversation Import Pipeline — multi-format conversation normalization + ingestion.
+ *
+ * Supports: Claude Code JSONL, Claude.ai JSON, ChatGPT JSON, Slack JSON, plaintext.
+ * Normalized messages are fed through the caller-provided ingest callback.
+ */
+
+import { readFileSync } from "node:fs";
+
+export interface NormalizedMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+  timestamp?: string;
+}
+
+export type ConversationFormat =
+  | "claude-code"
+  | "claude-ai"
+  | "chatgpt"
+  | "slack"
+  | "plaintext";
+
+// ---------------------------------------------------------------------------
+// Format detection
+// ---------------------------------------------------------------------------
+
+export function detectFormat(content: string): ConversationFormat {
+  const trimmed = content.trimStart();
+
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+
+      if (Array.isArray(parsed)) {
+        if (parsed.length > 0 && parsed[0].chat_messages !== undefined) return "claude-ai";
+        if (parsed.length > 0 && parsed[0].mapping !== undefined) return "chatgpt";
+        if (parsed.length > 0 && parsed[0].ts !== undefined && parsed[0].text !== undefined) return "slack";
+      }
+
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        if (parsed.chat_conversations !== undefined) return "claude-ai";
+        if (parsed.mapping !== undefined) return "chatgpt";
+        if (parsed.messages !== undefined && Array.isArray(parsed.messages)) {
+          const first = parsed.messages[0];
+          if (first && first.ts !== undefined) return "slack";
+        }
+      }
+    } catch {
+      // Not valid JSON
+    }
+  }
+
+  // JSONL: each line is a JSON object with type field
+  const firstLine = trimmed.split("\n")[0]?.trim();
+  if (firstLine?.startsWith("{")) {
+    try {
+      const obj = JSON.parse(firstLine);
+      if (obj.type === "human" || obj.type === "assistant" || obj.message !== undefined) {
+        return "claude-code";
+      }
+    } catch {
+      // Not JSONL
+    }
+  }
+
+  return "plaintext";
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code JSONL normalizer
+// ---------------------------------------------------------------------------
+
+interface ClaudeCodeLine {
+  type?: string;
+  message?: {
+    content?: string | Array<{ type?: string; text?: string }>;
+    role?: string;
+  };
+  timestamp?: string;
+}
+
+export function normalizeClaudeCode(content: string): NormalizedMessage[] {
+  const messages: NormalizedMessage[] = [];
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let parsed: ClaudeCodeLine;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+
+    let role: NormalizedMessage["role"];
+    if (parsed.type === "human") role = "user";
+    else if (parsed.type === "assistant") role = "assistant";
+    else if (parsed.message?.role === "user" || parsed.type === "user") role = "user";
+    else if (parsed.message?.role === "assistant") role = "assistant";
+    else continue;
+
+    let text = "";
+    const rawContent = parsed.message?.content;
+    if (typeof rawContent === "string") {
+      text = rawContent;
+    } else if (Array.isArray(rawContent)) {
+      text = rawContent
+        .filter((part): part is { type?: string; text?: string } =>
+          typeof part === "object" && part !== null && typeof part.text === "string")
+        .map((part) => part.text!)
+        .join("\n");
+    }
+
+    if (!text.trim()) continue;
+
+    messages.push({
+      role,
+      content: text.trim(),
+      ...(parsed.timestamp ? { timestamp: parsed.timestamp } : {}),
+    });
+  }
+
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Claude.ai JSON export normalizer
+// ---------------------------------------------------------------------------
+
+interface ClaudeAiConversation {
+  chat_messages?: Array<{
+    sender?: string;
+    text?: string;
+    created_at?: string;
+  }>;
+}
+
+export function normalizeClaudeAi(content: string): NormalizedMessage[] {
+  const parsed = JSON.parse(content);
+  const messages: NormalizedMessage[] = [];
+
+  let conversations: ClaudeAiConversation[];
+  if (Array.isArray(parsed)) conversations = parsed;
+  else if (parsed.chat_conversations) conversations = parsed.chat_conversations;
+  else conversations = [parsed];
+
+  for (const conv of conversations) {
+    if (!conv.chat_messages) continue;
+    for (const msg of conv.chat_messages) {
+      let role: NormalizedMessage["role"];
+      if (msg.sender === "human") role = "user";
+      else if (msg.sender === "assistant") role = "assistant";
+      else continue;
+
+      const text = msg.text?.trim();
+      if (!text) continue;
+
+      messages.push({
+        role,
+        content: text,
+        ...(msg.created_at ? { timestamp: msg.created_at } : {}),
+      });
+    }
+  }
+
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// ChatGPT conversations.json normalizer
+// ---------------------------------------------------------------------------
+
+interface ChatGPTMapping {
+  [id: string]: {
+    id: string;
+    parent?: string | null;
+    children?: string[];
+    message?: {
+      author?: { role?: string };
+      content?: { parts?: Array<string | Record<string, unknown>> };
+      create_time?: number;
+    } | null;
+  };
+}
+
+interface ChatGPTConversation {
+  mapping?: ChatGPTMapping;
+}
+
+export function normalizeChatGPT(content: string): NormalizedMessage[] {
+  const parsed = JSON.parse(content);
+  const messages: NormalizedMessage[] = [];
+  const conversations: ChatGPTConversation[] = Array.isArray(parsed) ? parsed : [parsed];
+
+  for (const conv of conversations) {
+    if (!conv.mapping) continue;
+    const mapping = conv.mapping;
+
+    let rootId: string | null = null;
+    for (const [id, node] of Object.entries(mapping)) {
+      if (!node.parent || !mapping[node.parent]) {
+        rootId = id;
+        break;
+      }
+    }
+    if (!rootId) continue;
+
+    const queue: string[] = [rootId];
+    const visited = new Set<string>();
+
+    while (queue.length > 0) {
+      const nodeId = queue.shift()!;
+      if (visited.has(nodeId)) continue;
+      visited.add(nodeId);
+
+      const node = mapping[nodeId];
+      if (!node) continue;
+
+      if (node.message?.author?.role && node.message.content?.parts) {
+        const authorRole = node.message.author.role;
+        let role: NormalizedMessage["role"] | null = null;
+        if (authorRole === "user") role = "user";
+        else if (authorRole === "assistant") role = "assistant";
+        else if (authorRole === "system") role = "system";
+
+        if (role) {
+          const text = node.message.content.parts
+            .filter((part): part is string => typeof part === "string")
+            .join("\n")
+            .trim();
+
+          if (text) {
+            const msg: NormalizedMessage = { role, content: text };
+            if (node.message.create_time) {
+              msg.timestamp = new Date(node.message.create_time * 1000).toISOString();
+            }
+            messages.push(msg);
+          }
+        }
+      }
+
+      if (node.children) {
+        for (const childId of node.children) queue.push(childId);
+      }
+    }
+  }
+
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Slack JSON export normalizer
+// ---------------------------------------------------------------------------
+
+interface SlackMessage {
+  user?: string;
+  bot_id?: string;
+  text?: string;
+  ts?: string;
+}
+
+export function normalizeSlack(content: string): NormalizedMessage[] {
+  const parsed = JSON.parse(content);
+  const messages: NormalizedMessage[] = [];
+
+  let rawMessages: SlackMessage[];
+  if (Array.isArray(parsed)) rawMessages = parsed;
+  else if (parsed.messages && Array.isArray(parsed.messages)) rawMessages = parsed.messages;
+  else return messages;
+
+  for (const msg of rawMessages) {
+    const text = msg.text?.trim();
+    if (!text) continue;
+
+    const role: NormalizedMessage["role"] = msg.bot_id ? "assistant" : "user";
+    const result: NormalizedMessage = { role, content: text };
+    if (msg.ts) {
+      result.timestamp = new Date(parseFloat(msg.ts) * 1000).toISOString();
+    }
+    messages.push(result);
+  }
+
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Plaintext normalizer
+// ---------------------------------------------------------------------------
+
+const ROLE_PREFIXES: Array<[RegExp, NormalizedMessage["role"]]> = [
+  [/^User:\s*/i, "user"],
+  [/^Human:\s*/i, "user"],
+  [/^Assistant:\s*/i, "assistant"],
+  [/^AI:\s*/i, "assistant"],
+  [/^System:\s*/i, "system"],
+];
+
+export function normalizePlaintext(content: string): NormalizedMessage[] {
+  const messages: NormalizedMessage[] = [];
+  let currentRole: NormalizedMessage["role"] | null = null;
+  let currentLines: string[] = [];
+
+  function flush() {
+    if (currentRole && currentLines.length > 0) {
+      const text = currentLines.join("\n").trim();
+      if (text) messages.push({ role: currentRole, content: text });
+    }
+    currentLines = [];
+  }
+
+  for (const line of content.split("\n")) {
+    let matched = false;
+    for (const [pattern, role] of ROLE_PREFIXES) {
+      const match = line.match(pattern);
+      if (match) {
+        flush();
+        currentRole = role;
+        const remainder = line.slice(match[0].length).trim();
+        if (remainder) currentLines.push(remainder);
+        matched = true;
+        break;
+      }
+    }
+    if (!matched && currentRole) currentLines.push(line);
+  }
+  flush();
+
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Unified normalize dispatcher
+// ---------------------------------------------------------------------------
+
+export function normalizeConversation(content: string, format: ConversationFormat): NormalizedMessage[] {
+  switch (format) {
+    case "claude-code": return normalizeClaudeCode(content);
+    case "claude-ai": return normalizeClaudeAi(content);
+    case "chatgpt": return normalizeChatGPT(content);
+    case "slack": return normalizeSlack(content);
+    case "plaintext": return normalizePlaintext(content);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Batch import: file → normalize → ingest callback
+// ---------------------------------------------------------------------------
+
+export interface ImportResult {
+  total: number;
+  stored: number;
+  skipped: number;
+  errors: string[];
+}
+
+export type IngestFn = (text: string, scope: string, role: string, timestamp?: string) => Promise<"stored" | "skipped">;
+
+export async function importConversationFile(
+  filePath: string,
+  scope: string,
+  format: ConversationFormat | "auto",
+  ingestFn: IngestFn,
+): Promise<ImportResult> {
+  const content = readFileSync(filePath, "utf-8");
+  const resolvedFormat = format === "auto" ? detectFormat(content) : format;
+  const messages = normalizeConversation(content, resolvedFormat);
+  return ingestNormalizedMessages(messages, scope, ingestFn);
+}
+
+export async function ingestNormalizedMessages(
+  messages: NormalizedMessage[],
+  scope: string,
+  ingestFn: IngestFn,
+): Promise<ImportResult> {
+  const result: ImportResult = { total: messages.length, stored: 0, skipped: 0, errors: [] };
+
+  for (const msg of messages) {
+    try {
+      const outcome = await ingestFn(msg.content, scope, msg.role, msg.timestamp);
+      if (outcome === "stored") result.stored++;
+      else result.skipped++;
+    } catch (err) {
+      result.errors.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return result;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,10 @@ export * from "./retriever.js";
 export { parseTemporalQuery, matchesTemporalFilter, applyTemporalFilter } from "./temporal-parser.js";
 export type { TemporalFilter } from "./temporal-parser.js";
 
+// Conversation import
+export { detectFormat, normalizeConversation, normalizeClaudeCode, normalizeClaudeAi, normalizeChatGPT, normalizeSlack, normalizePlaintext, importConversationFile, ingestNormalizedMessages } from "./conversation-importer.js";
+export type { NormalizedMessage, ConversationFormat, ImportResult, IngestFn } from "./conversation-importer.js";
+
 // Scopes
 export * from "./scopes.js";
 

--- a/packages/core/test/conversation-importer.test.mjs
+++ b/packages/core/test/conversation-importer.test.mjs
@@ -1,0 +1,299 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import jitiFactory from "jiti";
+
+const jiti = jitiFactory(import.meta.url, { interopDefault: true });
+
+const {
+  detectFormat,
+  normalizeClaudeCode,
+  normalizeClaudeAi,
+  normalizeChatGPT,
+  normalizeSlack,
+  normalizePlaintext,
+  normalizeConversation,
+  ingestNormalizedMessages,
+} = jiti("../src/conversation-importer.ts");
+
+// ============================================================================
+// Format detection
+// ============================================================================
+
+describe("detectFormat", () => {
+  it("detects Claude Code JSONL", () => {
+    const content = '{"type":"human","message":{"content":"hello"}}\n{"type":"assistant","message":{"content":"hi"}}';
+    assert.equal(detectFormat(content), "claude-code");
+  });
+
+  it("detects Claude.ai JSON (wrapper)", () => {
+    const content = JSON.stringify({ chat_conversations: [{ chat_messages: [] }] });
+    assert.equal(detectFormat(content), "claude-ai");
+  });
+
+  it("detects Claude.ai JSON (array)", () => {
+    const content = JSON.stringify([{ chat_messages: [{ sender: "human", text: "hi" }] }]);
+    assert.equal(detectFormat(content), "claude-ai");
+  });
+
+  it("detects ChatGPT JSON", () => {
+    const content = JSON.stringify([{ mapping: { "1": { id: "1", message: null } } }]);
+    assert.equal(detectFormat(content), "chatgpt");
+  });
+
+  it("detects Slack JSON (array)", () => {
+    const content = JSON.stringify([{ ts: "1234567890.123", text: "hello", user: "U123" }]);
+    assert.equal(detectFormat(content), "slack");
+  });
+
+  it("detects Slack JSON (wrapper)", () => {
+    const content = JSON.stringify({ messages: [{ ts: "1234567890.123", text: "hello" }] });
+    assert.equal(detectFormat(content), "slack");
+  });
+
+  it("falls back to plaintext", () => {
+    assert.equal(detectFormat("User: hello\nAssistant: hi"), "plaintext");
+  });
+});
+
+// ============================================================================
+// Claude Code JSONL
+// ============================================================================
+
+describe("normalizeClaudeCode", () => {
+  it("parses human/assistant types", () => {
+    const content = [
+      '{"type":"human","message":{"content":"What is 2+2?"}}',
+      '{"type":"assistant","message":{"content":"4"}}',
+    ].join("\n");
+    const msgs = normalizeClaudeCode(content);
+    assert.equal(msgs.length, 2);
+    assert.equal(msgs[0].role, "user");
+    assert.equal(msgs[0].content, "What is 2+2?");
+    assert.equal(msgs[1].role, "assistant");
+  });
+
+  it("handles array content blocks", () => {
+    const content = '{"type":"human","message":{"content":[{"type":"text","text":"Hello"},{"type":"text","text":"World"}]}}';
+    const msgs = normalizeClaudeCode(content);
+    assert.equal(msgs.length, 1);
+    assert.equal(msgs[0].content, "Hello\nWorld");
+  });
+
+  it("skips empty lines and invalid JSON", () => {
+    const content = "\n{invalid}\n";
+    assert.equal(normalizeClaudeCode(content).length, 0);
+  });
+
+  it("preserves timestamp", () => {
+    const content = '{"type":"human","message":{"content":"hi"},"timestamp":"2024-01-01T00:00:00Z"}';
+    const msgs = normalizeClaudeCode(content);
+    assert.equal(msgs[0].timestamp, "2024-01-01T00:00:00Z");
+  });
+});
+
+// ============================================================================
+// Claude.ai
+// ============================================================================
+
+describe("normalizeClaudeAi", () => {
+  it("parses chat_messages array", () => {
+    const content = JSON.stringify([{
+      chat_messages: [
+        { sender: "human", text: "hello" },
+        { sender: "assistant", text: "hi there" },
+      ],
+    }]);
+    const msgs = normalizeClaudeAi(content);
+    assert.equal(msgs.length, 2);
+    assert.equal(msgs[0].role, "user");
+    assert.equal(msgs[1].role, "assistant");
+  });
+
+  it("handles wrapper object", () => {
+    const content = JSON.stringify({
+      chat_conversations: [{
+        chat_messages: [{ sender: "human", text: "test" }],
+      }],
+    });
+    const msgs = normalizeClaudeAi(content);
+    assert.equal(msgs.length, 1);
+  });
+});
+
+// ============================================================================
+// ChatGPT
+// ============================================================================
+
+describe("normalizeChatGPT", () => {
+  it("rebuilds message order from mapping tree", () => {
+    const content = JSON.stringify({
+      mapping: {
+        root: {
+          id: "root",
+          parent: null,
+          children: ["msg1"],
+          message: null,
+        },
+        msg1: {
+          id: "msg1",
+          parent: "root",
+          children: ["msg2"],
+          message: {
+            author: { role: "user" },
+            content: { parts: ["Hello ChatGPT"] },
+            create_time: 1700000000,
+          },
+        },
+        msg2: {
+          id: "msg2",
+          parent: "msg1",
+          children: [],
+          message: {
+            author: { role: "assistant" },
+            content: { parts: ["Hello! How can I help?"] },
+            create_time: 1700000001,
+          },
+        },
+      },
+    });
+    const msgs = normalizeChatGPT(content);
+    assert.equal(msgs.length, 2);
+    assert.equal(msgs[0].role, "user");
+    assert.equal(msgs[0].content, "Hello ChatGPT");
+    assert.equal(msgs[1].role, "assistant");
+    assert.ok(msgs[0].timestamp);
+  });
+
+  it("handles array of conversations", () => {
+    const content = JSON.stringify([
+      { mapping: { r: { id: "r", parent: null, children: ["m"], message: null }, m: { id: "m", parent: "r", children: [], message: { author: { role: "user" }, content: { parts: ["hi"] } } } } },
+    ]);
+    const msgs = normalizeChatGPT(content);
+    assert.equal(msgs.length, 1);
+  });
+});
+
+// ============================================================================
+// Slack
+// ============================================================================
+
+describe("normalizeSlack", () => {
+  it("maps bot_id to assistant, user to user", () => {
+    const content = JSON.stringify([
+      { user: "U123", text: "question", ts: "1700000000.000" },
+      { bot_id: "B456", text: "answer", ts: "1700000001.000" },
+    ]);
+    const msgs = normalizeSlack(content);
+    assert.equal(msgs.length, 2);
+    assert.equal(msgs[0].role, "user");
+    assert.equal(msgs[1].role, "assistant");
+    assert.ok(msgs[0].timestamp);
+  });
+
+  it("handles wrapper with messages array", () => {
+    const content = JSON.stringify({
+      messages: [{ user: "U1", text: "hi", ts: "1700000000.000" }],
+    });
+    assert.equal(normalizeSlack(content).length, 1);
+  });
+
+  it("skips empty text", () => {
+    const content = JSON.stringify([{ user: "U1", text: "", ts: "1" }]);
+    assert.equal(normalizeSlack(content).length, 0);
+  });
+});
+
+// ============================================================================
+// Plaintext
+// ============================================================================
+
+describe("normalizePlaintext", () => {
+  it("splits by role prefixes", () => {
+    const content = "User: What is 2+2?\nAssistant: The answer is 4.";
+    const msgs = normalizePlaintext(content);
+    assert.equal(msgs.length, 2);
+    assert.equal(msgs[0].role, "user");
+    assert.equal(msgs[0].content, "What is 2+2?");
+    assert.equal(msgs[1].role, "assistant");
+  });
+
+  it("handles Human:/AI: prefixes", () => {
+    const content = "Human: hello\nAI: hi";
+    const msgs = normalizePlaintext(content);
+    assert.equal(msgs.length, 2);
+    assert.equal(msgs[0].role, "user");
+    assert.equal(msgs[1].role, "assistant");
+  });
+
+  it("handles multi-line content", () => {
+    const content = "User: Line 1\nLine 2\nAssistant: Reply";
+    const msgs = normalizePlaintext(content);
+    assert.equal(msgs.length, 2);
+    assert.ok(msgs[0].content.includes("Line 2"));
+  });
+
+  it("returns empty for text without role prefixes", () => {
+    assert.equal(normalizePlaintext("just some text").length, 0);
+  });
+});
+
+// ============================================================================
+// Dispatcher
+// ============================================================================
+
+describe("normalizeConversation", () => {
+  it("dispatches to correct normalizer", () => {
+    const jsonl = '{"type":"human","message":{"content":"test"}}';
+    const msgs = normalizeConversation(jsonl, "claude-code");
+    assert.equal(msgs.length, 1);
+    assert.equal(msgs[0].role, "user");
+  });
+});
+
+// ============================================================================
+// Batch ingest
+// ============================================================================
+
+describe("ingestNormalizedMessages", () => {
+  it("calls ingestFn for each message and tracks results", async () => {
+    const calls = [];
+    const ingestFn = async (text, scope, role) => {
+      calls.push({ text, scope, role });
+      return "stored";
+    };
+
+    const messages = [
+      { role: "user", content: "hello", timestamp: "2024-01-01T00:00:00Z" },
+      { role: "assistant", content: "hi" },
+    ];
+
+    const result = await ingestNormalizedMessages(messages, "project:test", ingestFn);
+    assert.equal(result.total, 2);
+    assert.equal(result.stored, 2);
+    assert.equal(result.skipped, 0);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].scope, "project:test");
+  });
+
+  it("tracks skipped messages", async () => {
+    const ingestFn = async () => "skipped";
+    const result = await ingestNormalizedMessages(
+      [{ role: "user", content: "x" }],
+      "scope",
+      ingestFn,
+    );
+    assert.equal(result.skipped, 1);
+    assert.equal(result.stored, 0);
+  });
+
+  it("tracks errors", async () => {
+    const ingestFn = async () => { throw new Error("fail"); };
+    const result = await ingestNormalizedMessages(
+      [{ role: "user", content: "x" }],
+      "scope",
+      ingestFn,
+    );
+    assert.equal(result.errors.length, 1);
+    assert.ok(result.errors[0].includes("fail"));
+  });
+});


### PR DESCRIPTION
## Summary

- Multi-format conversation normalization for importing chat history from **5 platforms**
- Auto-detects format from content structure — zero manual config needed
- Framework-agnostic ingest via callback pattern — not coupled to any specific pipeline

## Supported formats

| Format | Detection | Notes |
|--------|-----------|-------|
| Claude Code JSONL | `type: "human"/"assistant"` | `.claude/projects/` directory |
| Claude.ai JSON | `chat_conversations` wrapper | Official export format |
| ChatGPT JSON | `mapping` tree structure | `conversations.json` from data export |
| Slack JSON | `ts` + `text` fields | Channel export format |
| Plaintext | `User:`/`Human:`/`Assistant:`/`AI:` prefixes | Universal fallback |

## Changes

| File | Change |
|------|--------|
| `packages/core/src/conversation-importer.ts` | **New** — 5 normalizers + format detection + batch ingest |
| `packages/core/src/index.ts` | Export new functions and types |
| `packages/core/test/conversation-importer.test.mjs` | 26 tests |

## Integration example

```typescript
import { detectFormat, normalizeConversation, ingestNormalizedMessages } from "@anthropic/memory-core";

const content = readFileSync("conversations.json", "utf-8");
const format = detectFormat(content);
const messages = normalizeConversation(content, format);

await ingestNormalizedMessages(messages, "project:myapp", async (text, scope, role) => {
  await pipeline.ingest({ text, scope, category: "events", importance: 0.5, source: "conversation_import" });
  return "stored";
});
```

## Test plan

- [x] 26 unit tests pass (`node --test packages/core/test/conversation-importer.test.mjs`)
- [x] All 5 formats + auto-detection + edge cases covered
- [x] No changes to existing files except index.ts exports


🤖 Generated with [Claude Code](https://claude.com/claude-code)